### PR TITLE
[cu-2fr7t8x] Auto-detect function apps to test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,12 +33,13 @@ jobs:
           sudo apt-get install jq
       - id: find-python-apps
         name: Scan for python function apps
+        # use jq to produce json output and filter out the empty item caused by final newline
         run: |
-          echo "::set-output name=pydirs::$(find src/FunctionApps/ -mindepth 2 -maxdepth 2 -type f -name requirements.txt -printf "%P\n" |rev |cut -d/ -f2- |rev |jq --raw-input --slurp 'split("\n")' |jq --compact-output .[0:-1])"
+          echo "::set-output name=pydirs::$(find src/FunctionApps/ -mindepth 2 -maxdepth 2 -type f -name requirements.txt -printf "%P\n" |cut -d/ -f1 |jq --raw-input --slurp 'split("\n")' |jq --compact-output .[0:-1])"
       - id: find-java-apps
         name: Scan for java function apps
         run: |
-          echo "::set-output name=javadirs::$(find src/FunctionApps/ -mindepth 2 -maxdepth 2 -type f -name pom.xml -printf "%P\n" |rev |cut -d/ -f2- |rev |jq --raw-input --slurp 'split("\n")' |jq --compact-output .[0:-1])"
+          echo "::set-output name=javadirs::$(find src/FunctionApps/ -mindepth 2 -maxdepth 2 -type f -name pom.xml -printf "%P\n" |cut -d/ -f1 |jq --raw-input --slurp 'split("\n")' |jq --compact-output .[0:-1])"
       - name: Summary of detected apps
         run: |
           echo "Python (requirements.txt): ${{steps.find-python-apps.outputs.pydirs}}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,10 @@ jobs:
         name: Scan for java function apps
         run: |
           echo "::set-output name=javadirs::$(find src/FunctionApps/ -mindepth 2 -maxdepth 2 -type f -name pom.xml -printf "%P\n" |rev |cut -d/ -f2- |rev |jq --raw-input --slurp 'split("\n")' |jq --compact-output .[0:-1])"
+      - name: Summary of detected apps
+        run: |
+          echo "Python (requirements.txt): ${{steps.find-python-apps.outputs.pydirs}}"
+          echo "Java (pom.xml): ${{steps.find-java-apps.outputs.javadirs}}"
     outputs:
       python-function-app-dirs: ${{steps.find-python-apps.outputs.pydirs}}
       java-function-app-dirs: ${{steps.find-java-apps.outputs.javadirs}}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,16 @@ env:
   TEST_RUNNER_TERRAFORM_VERSION: 1.1.5
 
 jobs:
-  unit-test-scanner:
+  function-app-scan:
+    # Find directories that contain function apps in python or java
+    #
+    # Look for a files in function app directories to determine the language used
+    # and output a list of directory names for functions of each language.  Language
+    # is determined based on the existence of a file inside the top-level function
+    # app directory, currently:
+    #     python: `requirements.txt`
+    #     java: `pom.xml`
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,23 +34,21 @@ jobs:
       - id: find-python-apps
         name: Scan for python function apps
         run: |
-          echo "::set-output name=pydirs::$(find src/FunctionApps/ -maxdepth 2 -type f -name requirements.txt -printf "%P\n" |rev |cut -d/ -f2- |rev |jq --raw-input --slurp 'split("\n")' |jq --compact-output .[0:-1])"
+          echo "::set-output name=pydirs::$(find src/FunctionApps/ -mindepth 2 -maxdepth 2 -type f -name requirements.txt -printf "%P\n" |rev |cut -d/ -f2- |rev |jq --raw-input --slurp 'split("\n")' |jq --compact-output .[0:-1])"
       - id: find-java-apps
         name: Scan for java function apps
         run: |
-          echo "::set-output name=javadirs::$(find src/FunctionApps/ -maxdepth 2 -type f -name pom.xml -printf "%P\n" |rev |cut -d/ -f2- |rev |jq --raw-input --slurp 'split("\n")' |jq --compact-output .[0:-1])"
+          echo "::set-output name=javadirs::$(find src/FunctionApps/ -mindepth 2 -maxdepth 2 -type f -name pom.xml -printf "%P\n" |rev |cut -d/ -f2- |rev |jq --raw-input --slurp 'split("\n")' |jq --compact-output .[0:-1])"
     outputs:
       python-function-app-dirs: ${{steps.find-python-apps.outputs.pydirs}}
       java-function-app-dirs: ${{steps.find-java-apps.outputs.javadirs}}
 
-
   unit-test-python:
-    needs: unit-test-scanner
+    needs: function-app-scan
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        function-to-test: ${{fromJson(needs.unit-test-scanner.outputs.python-function-app-dirs)}}
-
+        function-to-test: ${{fromJson(needs.function-app-scan.outputs.python-function-app-dirs)}}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -64,12 +69,11 @@ jobs:
           python -m pytest
 
   unit-test-java:
-    needs: unit-test-scanner
+    needs: function-app-scan
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        function-to-test: ${{fromJson(needs.unit-test-scanner.outputs.java-function-app-dirs)}}
-
+        function-to-test: ${{fromJson(needs.function-app-scan.outputs.java-function-app-dirs)}}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -99,7 +103,6 @@ jobs:
 
   code-check-python:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -124,7 +127,6 @@ jobs:
     defaults:
       run:
         working-directory: ./operations
-
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,15 +15,34 @@ env:
   TEST_RUNNER_TERRAFORM_VERSION: 1.1.5
 
 jobs:
+  unit-test-scanner:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt-get install jq
+      - id: find-python-apps
+        name: Scan for python function apps
+        run: |
+          echo "::set-output name=pydirs::$(find src/FunctionApps/ -maxdepth 2 -type f -name requirements.txt -printf "%P\n" |rev |cut -d/ -f2- |rev |jq --raw-input --slurp 'split("\n")' |jq --compact-output .[0:-1])"
+      - id: find-java-apps
+        name: Scan for java function apps
+        run: |
+          echo "::set-output name=javadirs::$(find src/FunctionApps/ -maxdepth 2 -type f -name pom.xml -printf "%P\n" |rev |cut -d/ -f2- |rev |jq --raw-input --slurp 'split("\n")' |jq --compact-output .[0:-1])"
+    outputs:
+      python-function-app-dirs: ${{steps.find-python-apps.outputs.pydirs}}
+      java-function-app-dirs: ${{steps.find-java-apps.outputs.javadirs}}
+
+
   unit-test-python:
+    needs: unit-test-scanner
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        function-to-test:
-          - PHDISmartyStreetsTest
-          - PITest_FunctionApp
-          - CachedGeocode
-          - FHIRExport
+        function-to-test: ${{fromJson(needs.unit-test-scanner.outputs.python-function-app-dirs)}}
 
     steps:
       - name: Checkout
@@ -45,11 +64,11 @@ jobs:
           python -m pytest
 
   unit-test-java:
+    needs: unit-test-scanner
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        function-to-test:
-          - DSTP
+        function-to-test: ${{fromJson(needs.unit-test-scanner.outputs.java-function-app-dirs)}}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Fixes https://app.clickup.com/t/2fr7t8x

### Description

Scan the directory `src/FunctionApps` and look for directories containing a function app that needs to have tests run on it.

This will remove the need to update the workflow when a function app is added or removed.

#### Determining language

This is done by looking into each top-level directory under `FunctionApps` for a file.  If a `requirements.txt` file exists, the directory is determined to have a python function app in it.  Java/Kotlin apps are contain a `pom.xml` file (the workflow currently only supports maven).  Lists of the found function apps are used to set the matrix of python and java apps to tests.

#### Workflow modification

1. Add a new job that generates lists of function-app directory names and sets them as outputs
2. Make the unit test matrix jobs dependent on the new job
3. Use the outputs from the new job to set the matrix parameter for each unit test job

### Notes

The scan outputs a list of only the directory names.  This makes detecting the function apps a little bit messier, but the benefit is that it is easy to generate nice job names for the workflow output.  For the time being, they will remain the same as they were before this modification, for example: `unit-test-python (FHIRExport)`.

