### PR TITLE
Change getAccessToken() to authenticate via Default Azure Credential

### DIFF
--- a/src/FunctionApps/DSTP/pom.xml
+++ b/src/FunctionApps/DSTP/pom.xml
@@ -60,14 +60,9 @@
             <version>${functions.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.azure.identity</groupId>
+            <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
             <version>1.4.6</version>
-        </dependency>
-        <dependency>
-            <groupId>com.azure.core.credential</groupId>
-            <artifactId>azure-core</artifactId>
-            <version>1.26.0</version>
         </dependency>
         <!-- Kotlin -->
         <dependency>

--- a/src/FunctionApps/DSTP/pom.xml
+++ b/src/FunctionApps/DSTP/pom.xml
@@ -59,7 +59,16 @@
             <artifactId>azure-functions-java-library</artifactId>
             <version>${functions.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.azure.identity</groupId>
+            <artifactId>azure-identity</artifactId>
+            <version>1.4.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.azure.core.credential</groupId>
+            <artifactId>azure-core</artifactId>
+            <version>1.26.0</version>
+        </dependency>
         <!-- Kotlin -->
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
We have changed the authentication process with the FHIR server to use [Default Azure Credential](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) as opposed to reading a client_id and client_secret from a local.settings.json file. This change is necessary in order to authenticate with the FHIR server in CDC Azure because the additional security measures that were recently implemented have removed access to client_id and client_secret. We also benefit from this change because Default Azure Credential abstracts the authentication process allowing our code to authenticate in the same way regardless of whether it is running locally or in the cloud. 

Beyond a re-write getAccessToken() changes have been made to pom.xml to support the 2 additional required dependencies. 
