### PR TITLE
Fix title and date format for ADR #4

### DIFF
--- a/docs/decisions/0004-working-with-fhir-data.md
+++ b/docs/decisions/0004-working-with-fhir-data.md
@@ -1,6 +1,6 @@
-# 0003 Working with FHIR Data
+# 4. Working with FHIR Data
 
-Date: Feb 22, 2022
+Date: 2022-02-22
 
 ## Status
 


### PR DESCRIPTION
# Description

I know ADRs should be immutable once approved or rejected, but this ADR was approved despite inconsistent formatting. Typically I'd let that go, but the title didn't even match the ADR given that the title was `0003 Working with FHIR Data` and this is ADR #4. Given that this needs to be changed, I'm taking the opportunity to also modify the date format to be consistent with the other ADRs.