### PR TITLE
Explicitly state data format in ADR and make Appendix optional

### DIFF
--- a/docs/decisions/template.md
+++ b/docs/decisions/template.md
@@ -1,6 +1,6 @@
-# [NUMBER] [TITLE]
+# [NUMBER]. [TITLE]
 
-Date: [DATE PROPOSED]
+Date: [DATE PROPOSED (YYYY-MM-DD)]
 
 ## Status
 
@@ -22,6 +22,6 @@ What other options were considered, and what pros and cons exist around these de
 
 What decision did you go forward with, and how does it map to the above decision drivers?
 
-## Appendix
+## Appendix (OPTIONAL)
 
 Add any links here that are relevant for understanding your proposal or its background.


### PR DESCRIPTION
# Description
This PR updates the ADR template to explicitly provide a data format (YYYY-MM-DD) and list the Appendix section as optional. Of the 4 ADRs that have merged to date, 3 of the 4 followed these standards, but ADR 4 showed some variability, so I'm making these updates to make it more explicit what we're looking for in ADRs. 