### PR TITLE
Add ADR requiring checks to pass before approvals are made

### DIFF
--- a/docs/decisions/0007-pr-approval-requires-checks-to-pass.md
+++ b/docs/decisions/0007-pr-approval-requires-checks-to-pass.md
@@ -18,7 +18,7 @@ One of the conditions that must be met before a Pull Request can be merged into 
 
 ## Considered Options
 
-No other options were considered.
+We could simply require that all status checks pass before allowing merges, a solution that has been submitted as [ADR #8](https://github.com/CDCgov/prime-public-health-data-infrastructure/blob/main/docs/decisions/0008-merging-prs-requires-checks-to-pass.md). This would nullify the need for this ADR as the risk of merging a PR with unsuccessful status checks would no longer exist.
 
 ## Decision Outcome
 

--- a/docs/decisions/0007-pr-approval-requires-checks-to-pass.md
+++ b/docs/decisions/0007-pr-approval-requires-checks-to-pass.md
@@ -4,7 +4,7 @@ Date: 2022-03-27
 
 ## Status
 
-Proposed
+Rejected
 
 ## Context and Problem Statement
 

--- a/docs/decisions/0007-pr-approvals-require-checks-to-pass.md
+++ b/docs/decisions/0007-pr-approvals-require-checks-to-pass.md
@@ -1,0 +1,25 @@
+# 7. Pull Request Approvals Require All Checks to be Passing
+
+Date: 2022-03-27
+
+## Status
+
+Proposed
+
+## Context and Problem Statement
+
+One of the conditions that must be met before a Pull Request can be merged into `main` is that at least one person review the code. Unfortunately, this condition is not dependent on the checks that are also in place in the repo, and as a result a developer could merge an approved Pull Request, even if the checks are failing.
+
+## Decision Drivers
+
+**Quality -** Developers should be giving their full attention to Pull Requests and making sure that we're all holding each other to the highest standards with our code.  
+**Confidence -** Developers should feel confident that when another developer say their code is good to go that that implies a genuine stamp of approval.  
+**Trust -** Users of our code should trust it works as intended.
+
+## Considered Options
+
+No other options were considered.
+
+## Decision Outcome
+
+A developer should not approve a Pull Request until all checks have run and returned a successful result. 

--- a/docs/decisions/0008-merging-prs-requires-checks-to-pass.md
+++ b/docs/decisions/0008-merging-prs-requires-checks-to-pass.md
@@ -1,0 +1,25 @@
+# 8. Pull Request Approvals Require All Checks to be Passing
+
+Date: 2022-03-27
+
+## Status
+
+Proposed
+
+## Context and Problem Statement
+
+Merging a Pull Request into the `main` branch does not currently require that the status checks we have in place all be passing. As a result a developer could merge an approved Pull Request, even if the checks are failing.
+
+## Decision Drivers
+
+**Quality -** Developers should be giving their full attention to Pull Requests and making sure that we're all holding each other to the highest standards with our code.  
+**Confidence -** Developers should feel confident that when another developer say their code is good to go that that implies a genuine stamp of approval.  
+**Trust -** Users of our code should trust it works as intended.
+
+## Considered Options
+
+We could require that all status checks pass before a developer approves the PR, a solution that has been submitted as [ADR #7](https://github.com/CDCgov/prime-public-health-data-infrastructure/blob/main/docs/decisions/0007-pr-approval-requires-checks-to-pass.md). This wouldn't necessarily nullify the need for this ADR, but it would provide some extra reassurances that approvals are being handed out dutifully. 
+
+## Decision Outcome
+
+All status checks must pass before a merge can take place, and this is enforced through the repo's settings under branch protection.

--- a/docs/decisions/0008-merging-prs-requires-checks-to-pass.md
+++ b/docs/decisions/0008-merging-prs-requires-checks-to-pass.md
@@ -4,7 +4,7 @@ Date: 2022-03-27
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context and Problem Statement
 

--- a/docs/decisions/0008-merging-prs-requires-checks-to-pass.md
+++ b/docs/decisions/0008-merging-prs-requires-checks-to-pass.md
@@ -1,4 +1,4 @@
-# 8. Pull Request Approvals Require All Checks to be Passing
+# 8. Merging Pull Requests Requires All Checks to be Passing
 
 Date: 2022-03-27
 


### PR DESCRIPTION
# Description
Pull Requests require both that all checks that have been implemented pass and that at least 1 developer approve the pull request. Unfortunately, there's no way to ensure that a developer is only approving pull requests that have passed all checks, which can result in an opportunity for developers to merge PRs with unsuccessful checks. This PR introduces two ADRs, which encompass two different solutions to this. I assume that one of the ADRs will be rejected in favor of the other, but I wanted to provide both as an option.

# Feedback Requested
- Which of these seems like the best approach to ensuring bad merges don't take place?  
- Is there another option I'm not considering?