### PR TITLE
Graham/jsonify dstp

### DIFF
--- a/src/FunctionApps/DSTP/src/main/kotlin/gov/cdc/prime/phdi/ConvertToFHIR.kt
+++ b/src/FunctionApps/DSTP/src/main/kotlin/gov/cdc/prime/phdi/ConvertToFHIR.kt
@@ -88,18 +88,18 @@ class ConvertToFHIR {
             if (messageCategory.equals("ecr") || isValidHL7Message(it)) {
                 try {
                     val json = convertMessageToFHIR(
-                        it, 
-                        messageFormat, 
+                        it,
+                        messageFormat,
                         messageType,
                         accessToken
                     )
                     if (isValidFHIRMessage(json)) {
-                        validMessages.append("$json\n")
+                        validMessages.append("$json,\n")
                     } else {
                         context.logger.info(
                             "The FHIR Server failed to convert a $messageCategory message."
                         )
-                        invalidMessages.append("$it\n")
+                        invalidMessages.append("$it,\n")
                     }
                 } catch (e: Exception) {
                     val msg: String = """
@@ -117,11 +117,11 @@ class ConvertToFHIR {
         }
 
         if (validMessages.isNotBlank()) {
-            validContent.setValue(validMessages.toString().trim())
+            validContent.setValue("[" + validMessages.toString().trim().trim(',') + "]")
         }
 
         if (invalidMessages.isNotBlank()) {
-            invalidContent.setValue(invalidMessages.toString().trim())
+            invalidContent.setValue("[" + invalidMessages.toString().trim().trim(',') + "]")
         }
     }
 }

--- a/src/FunctionApps/DSTP/src/main/kotlin/gov/cdc/prime/phdi/ConvertToFHIR.kt
+++ b/src/FunctionApps/DSTP/src/main/kotlin/gov/cdc/prime/phdi/ConvertToFHIR.kt
@@ -20,20 +20,20 @@ class ConvertToFHIR {
             name = "file",
             dataType = "binary",
             path = "bronze/decrypted/{name}",
-            connection="LOCALAzureWebJobsStorage"
+            connection="AzureWebJobsStorage"
         ) content: ByteArray,
         @BindingName("name") filename: String,
         @BlobOutput(
             name="validTarget",
             dataType = "string",
             path="bronze/valid-messages/{name}.fhir",
-            connection="LOCALAzureWebJobsStorage"
+            connection="AzureWebJobsStorage"
         ) validContent: OutputBinding<String>,
         @BlobOutput(
             name="invalidTarget",
             dataType = "string",
             path="bronze/invalid-messages/{name}.txt",
-            connection="LOCALAzureWebJobsStorage"
+            connection="AzureWebJobsStorage"
         ) invalidContent: OutputBinding<String>,
         context: ExecutionContext
 	) {


### PR DESCRIPTION
Previously the files returned by convertToFHIR() were a hybrid of nicely formatted JSON (containing line breaks and indents) and NDJSON. Despite being human-readable these files could not be read programmatically line by line. This change removes all line breaks within the string returned from convertMessageToFHIR(), but continues to append these strings together with line feeds. The result are files that contain the entire FHIR bundle from single HL7 message on one line. Our ability to read these files has been tested with Python's `ndjson.loads(<file-as-string>) and json.loads(<one-line-of-file>)`.