### PR TITLE
Add ELR parsing to CSVs

### DIFF
--- a/src/FunctionApps/python/GenerateCSVs/__init__.py
+++ b/src/FunctionApps/python/GenerateCSVs/__init__.py
@@ -39,7 +39,7 @@ def generate_csvs() -> dict[str, io.StringIO]:
     # For each record, run the associated function and write the appropriate csv
     for rtype, bundle in read_bundles_by_type():
         cols, fn = RECORD_TYPES[rtype]
-        writers[rtype].writerow(fn(bundle))
+        writers[rtype].writerows(fn(bundle))
 
     return results
 

--- a/src/FunctionApps/python/GenerateCSVs/elr.py
+++ b/src/FunctionApps/python/GenerateCSVs/elr.py
@@ -2,17 +2,16 @@ from typing import List, Any
 from GenerateCSVs.patient import PATIENT_COLUMNS, parse_patient_resource
 
 
-ELR_COLUMNS = PATIENT_COLUMNS + ["loinc_code", "result", "effective_date"]
+ELR_COLUMNS = PATIENT_COLUMNS + ["loincCode", "result", "effectiveDateTime"]
 
 
-def extract_covid_test(observation: dict) -> dict:
+def extract_loinc_lab(observation: dict) -> List[str]:
     """
     Given an observation FHIR profile, determine whether the profile
-    contains information related to a COVID test or COVID status.
+    contains information related to a laboratory test and result.
     If yes, collect the relevant lab code, test result, and test
     date into a list.
     """
-    print(observation)
     code = observation["code"]["coding"][0]
     if "loinc" in code["system"] and "valueCodeableConcept" in observation:
         obs_date = observation["effectiveDateTime"]
@@ -21,19 +20,26 @@ def extract_covid_test(observation: dict) -> dict:
     return []
 
 
-def elr_to_csv(bundle: dict) -> List[Any]:
+def elr_to_csv(bundle: dict) -> List[List[str]]:
     """
     Given a FHIR bundle containing a patient resource and one or more
     ELR lab observations, identify the labs related to COVID and turn
     them into patient-identified rows for use in a CSV.
     """
     rows_to_write = []
-    row_root = []
+    patient_info_list = []
     for resource in bundle["entry"]:
         if resource["resource"]["resourceType"] == "Patient":
-            row_root.extend(parse_patient_resource(resource))
+            patient_info_list.extend(parse_patient_resource(resource))
         elif resource["resource"]["resourceType"] == "Observation":
-            obs_info = extract_covid_test(resource["resource"])
+
+            # We only care about observations related to covid testing
+            obs_info = extract_loinc_lab(resource["resource"])
             if len(obs_info) > 0:
-                rows_to_write.append(row_root + obs_info)
+                rows_to_write.append(obs_info)
+
+    # Now pre-pend the patient information to each row
+    # Handles case where Patient resource comes after 1+ obs profiles
+    for i in range(len(rows_to_write)):
+        rows_to_write[i] = patient_info_list + rows_to_write[i]
     return rows_to_write

--- a/src/FunctionApps/python/GenerateCSVs/elr.py
+++ b/src/FunctionApps/python/GenerateCSVs/elr.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import List
 from GenerateCSVs.patient import PATIENT_COLUMNS, parse_patient_resource
 
 

--- a/src/FunctionApps/python/GenerateCSVs/elr.py
+++ b/src/FunctionApps/python/GenerateCSVs/elr.py
@@ -1,8 +1,39 @@
 from typing import List, Any
-from GenerateCSVs.patient import PATIENT_COLUMNS
+from GenerateCSVs.patient import PATIENT_COLUMNS, parse_patient_resource
 
-ELR_COLUMNS = PATIENT_COLUMNS + []
+
+ELR_COLUMNS = PATIENT_COLUMNS + ["loinc_code", "result", "effective_date"]
+
+
+def extract_covid_test(observation: dict) -> dict:
+    """
+    Given an observation FHIR profile, determine whether the profile
+    contains information related to a COVID test or COVID status.
+    If yes, collect the relevant lab code, test result, and test
+    date into a list.
+    """
+    print(observation)
+    code = observation["code"]["coding"][0]
+    if "loinc" in code["system"] and "valueCodeableConcept" in observation:
+        obs_date = observation["effectiveDateTime"]
+        result = observation["valueCodeableConcept"]["coding"][0]["display"]
+        return [code["code"], result, obs_date]
+    return []
 
 
 def elr_to_csv(bundle: dict) -> List[Any]:
-    pass
+    """
+    Given a FHIR bundle containing a patient resource and one or more
+    ELR lab observations, identify the labs related to COVID and turn
+    them into patient-identified rows for use in a CSV.
+    """
+    rows_to_write = []
+    row_root = []
+    for resource in bundle["entry"]:
+        if resource["resource"]["resourceType"] == "Patient":
+            row_root.extend(parse_patient_resource(resource))
+        elif resource["resource"]["resourceType"] == "Observation":
+            obs_info = extract_covid_test(resource["resource"])
+            if len(obs_info) > 0:
+                rows_to_write.append(row_root + obs_info)
+    return rows_to_write

--- a/src/FunctionApps/python/tests/GenerateCSVs/assets/elr.json
+++ b/src/FunctionApps/python/tests/GenerateCSVs/assets/elr.json
@@ -1,0 +1,128 @@
+{
+    "resourceType": "Bundle",
+    "identifier": {
+        "value": "a very contrived FHIR bundle"
+    },
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "Organization",
+                "id": "some-org-we-dont-care-about"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "some-uuid",
+                "identifier": [
+                    {
+                        "value": "123456",
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "MR",
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "display": "Medical record number"
+                                }
+                            ]
+                        },
+                        "system": "urn...no idea"
+                    }
+                ],
+                "name": [
+                    {
+                        "family": "Shepard",
+                        "given": [
+                            "John"
+                        ],
+                        "use": "official"
+                    }
+                ],
+                "birthDate": "2153-11-07",
+                "gender": "Male",
+                "address": [
+                    {
+                        "line": [
+                            "1234 Silversun Strip"
+                        ],
+                        "city": "Zakera Ward",
+                        "state": "Citadel",
+                        "postalCode": "99999",
+                        "country": "Canada",
+                        "use": "home"
+                    }
+                ],
+                "telecom": [
+                    {
+                        "use": "home",
+                        "system": "phone"
+                    },
+                    {
+                        "value": "johndanger@doe.net",
+                        "system": "email"
+                    }
+                ],
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+                        "extension": [
+                            {
+                                "valueCoding": {
+                                    "code": "White"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "another-id",
+                "code": {
+                    "coding": [
+                        {
+                            "code": "94500-6",
+                            "display": "SARS-CoV-2 RNA Resp Ql NAA+probe",
+                            "system": "http://loinc.org"
+                        }
+                    ]
+                },
+                "valueCodeableConcept": {
+                    "coding": [
+                        {
+                            "code": "10828004",
+                            "display": "Positive",
+                            "system": "http://terminology.hl7.org/CodeSystem/snm"
+                        }
+                    ],
+                    "text": "Positive"
+                },
+                "effectiveDateTime": "2022-01-01T01:01:00",
+                "subject": {
+                    "reference": "Patient/some-uuid"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "yet-another-id",
+                "code": {
+                    "coding": [
+                        {
+                            "code": "fake-code",
+                            "display": "i do not exist",
+                            "system": "lolwut"
+                        }
+                    ]
+                },
+                "effectiveDateTime": "2022-01-01T01:01:00",
+                "subject": {
+                    "reference": "Patient/some-uuid"
+                }
+            }
+        }
+    ]
+}

--- a/src/FunctionApps/python/tests/GenerateCSVs/assets/observation.json
+++ b/src/FunctionApps/python/tests/GenerateCSVs/assets/observation.json
@@ -1,0 +1,51 @@
+{
+    "resourceType": "Observation",
+    "id": "321asdf-5555-4995-d8e5-3sd8fv1j86a",
+    "status": "final",
+    "code": {
+        "coding": [
+            {
+                "code": "94500-6",
+                "display": "SARS-CoV-2 RNA Resp Ql NAA+probe",
+                "system": "http://loinc.org"
+            }
+        ]
+    },
+    "valueCodeableConcept": {
+        "coding": [
+            {
+                "code": "10828004",
+                "display": "Positive",
+                "system": "http://terminology.hl7.org/CodeSystem/snm"
+            }
+        ],
+        "text": "Positive"
+    },
+    "effectiveDateTime": "2022-01-01T01:01:00",
+    "method": {
+        "coding": [
+            {
+                "code": "XPERT XPRESS SARS-COV-2 TEST_CEPHEID_EUA",
+                "system": "http://example.com/v2-to-fhir-converter/CodeSystem/99ELR"
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/8s5f4j6s-be04-1234-9876-5j813d9e31q8"
+    },
+    "extension": [
+        {
+            "url": "http://example.com/v2-to-fhir-converter/Observation_Status",
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "code": "F",
+                        "display": "Final",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0085"
+                    }
+                ],
+                "text": "Final"
+            }
+        }
+    ]
+}

--- a/src/FunctionApps/python/tests/GenerateCSVs/test_elr.py
+++ b/src/FunctionApps/python/tests/GenerateCSVs/test_elr.py
@@ -1,11 +1,11 @@
 import json
 import pathlib
-from GenerateCSVs.elr import extract_covid_test
+from GenerateCSVs.elr import extract_loinc_lab
 from GenerateCSVs.elr import elr_to_csv
 import pytest
 
 
-def test_extract_covid_test():
+def test_extract_loinc_lab():
     covid_obs = json.load(
         open(pathlib.Path(__file__).parent / "assets" / "observation.json")
     )
@@ -23,8 +23,8 @@ def test_extract_covid_test():
             ]
         },
     }
-    assert extract_covid_test(non_covid_obs) == []
-    assert extract_covid_test(covid_obs) == [
+    assert extract_loinc_lab(non_covid_obs) == []
+    assert extract_loinc_lab(covid_obs) == [
         "94500-6",
         "Positive",
         "2022-01-01T01:01:00",

--- a/src/FunctionApps/python/tests/GenerateCSVs/test_elr.py
+++ b/src/FunctionApps/python/tests/GenerateCSVs/test_elr.py
@@ -1,0 +1,62 @@
+import json
+import pathlib
+from GenerateCSVs.elr import extract_covid_test
+from GenerateCSVs.elr import elr_to_csv
+import pytest
+
+
+def test_extract_covid_test():
+    covid_obs = json.load(
+        open(pathlib.Path(__file__).parent / "assets" / "observation.json")
+    )
+    non_covid_obs = {
+        "resourceType": "Observation",
+        "id": "some-id",
+        "status": "final",
+        "code": {
+            "coding": [
+                {
+                    "code": "123456",
+                    "display": "some sorta health thing",
+                    "system": "http://blah.org",
+                }
+            ]
+        },
+    }
+    assert extract_covid_test(non_covid_obs) == []
+    assert extract_covid_test(covid_obs) == [
+        "94500-6",
+        "Positive",
+        "2022-01-01T01:01:00",
+    ]
+
+
+@pytest.fixture()
+def bundle():
+    return json.load(open(pathlib.Path(__file__).parent / "assets" / "elr.json"))
+
+
+def test_elr_to_csv(bundle):
+    generated_rows = elr_to_csv(bundle)
+    num_rows = 0
+    for row in generated_rows:
+        num_rows += 1
+        assert row == [
+            "",
+            "John",
+            "Shepard",
+            "2153-11-07",
+            "Male",
+            "1234 Silversun Strip",
+            "Zakera Ward",
+            "Citadel",
+            "99999",
+            "",
+            "",
+            "White",
+            "",
+            "94500-6",
+            "Positive",
+            "2022-01-01T01:01:00",
+        ]
+    assert num_rows == 1

--- a/src/FunctionApps/python/tests/GenerateCSVs/test_main.py
+++ b/src/FunctionApps/python/tests/GenerateCSVs/test_main.py
@@ -18,9 +18,9 @@ def test_generate_csvs(mock_bundle_reader):
     ]
 
     mock_types_def = {
-        RECORD_TYPE_VXU: (["vxucol"], mock.Mock(return_value=["vxurec"])),
-        RECORD_TYPE_ELR: (["elrcol"], mock.Mock(return_value=["elrrec"])),
-        RECORD_TYPE_ECR: (["ecrcol"], mock.Mock(return_value=["ecrrec"])),
+        RECORD_TYPE_VXU: (["vxucol"], mock.Mock(return_value=[["vxurec"]])),
+        RECORD_TYPE_ELR: (["elrcol"], mock.Mock(return_value=[["elrrec"]])),
+        RECORD_TYPE_ECR: (["ecrcol"], mock.Mock(return_value=[["ecrrec"]])),
     }
 
     with mock.patch("GenerateCSVs.RECORD_TYPES", mock_types_def):


### PR DESCRIPTION
This PR introduces the functionality needed for us to generate csv rows from ELR data. Using Dan's patient extractor function, this changeset extends that by identifying COVID related observations and incorporating relevant fields into the generated rows. Tests are included for the individual function.

Also, per slack discussion, the return type of all functions should be modified to a list of lists. I've done that for the ELR function and also set up the main functions (and tests) to work with that data type.