### PR TITLE
Refactor FHIR bundle upload and expand test coverage

### DIFF
--- a/src/FunctionApps/python/IntakePipeline/__init__.py
+++ b/src/FunctionApps/python/IntakePipeline/__init__.py
@@ -9,7 +9,6 @@ from IntakePipeline.fhir import (
     store_data,
     generate_filename,
     get_fhirserver_cred_manager,
-    AzureFhirserverCredentialManager,
 )
 from IntakePipeline.conversion import (
     convert_batch_messages_to_list,
@@ -25,7 +24,6 @@ def run_pipeline(
     message_mappings: Dict[str, str],
     fhir_url: str,
     access_token: str,
-    cred_manager: AzureFhirserverCredentialManager,
 ) -> None:
     """
     This function takes in a single message and runs it through the Data
@@ -64,7 +62,7 @@ def run_pipeline(
             message_mappings["bundle_type"],
             bundle=bundle,
         )
-        upload_bundle_to_fhir_server(cred_manager, bundle)
+        upload_bundle_to_fhir_server(bundle, access_token, fhir_url)
     else:
         store_data(
             container_url,
@@ -92,9 +90,7 @@ def main(blob: func.InputStream) -> func.HttpResponse:
 
         for i, message in enumerate(messages):
             message_mappings["filename"] = generate_filename(blob.name, i)
-            run_pipeline(
-                message, message_mappings, fhir_url, access_token.token, cred_manager
-            )
+            run_pipeline(message, message_mappings, fhir_url, access_token.token)
     except Exception:
         logging.exception("exception caught while running the intake pipeline")
         return func.HttpResponse(

--- a/src/FunctionApps/python/tests/IntakePipeline/fhir_test.py
+++ b/src/FunctionApps/python/tests/IntakePipeline/fhir_test.py
@@ -37,18 +37,7 @@ def test_store_bundle(mock_get_client):
 
 @mock.patch("requests.post")
 def test_upload_bundle_to_fhir_server(mock_fhir_post):
-
-    mock_fhirserver_cred_manager = mock.Mock()
-    mock_fhirserver_cred_manager.fhir_url = "https://fhir-url"
-
-    # Create a mock token
-    mock_access_token = mock.Mock()
-    mock_access_token.token = "my-token"
-    mock_access_token.expires_on = datetime.now(timezone.utc).timestamp() + 2399
-    mock_fhirserver_cred_manager.get_access_token.return_value = mock_access_token
-
     upload_bundle_to_fhir_server(
-        mock_fhirserver_cred_manager,
         {
             "resourceType": "Bundle",
             "id": "some-id",
@@ -59,12 +48,14 @@ def test_upload_bundle_to_fhir_server(mock_fhir_post):
                 }
             ],
         },
+        "some-token",
+        "https://some-fhir-url"
     )
 
     mock_fhir_post.assert_called_with(
-        "https://fhir-url",
+        "https://some-fhir-url",
         headers={
-            "Authorization": "Bearer my-token",
+            "Authorization": "Bearer some-token",
             "Accept": "application/fhir+json",
             "Content-Type": "application/fhir+json",
         },

--- a/src/FunctionApps/python/tests/IntakePipeline/fhir_test.py
+++ b/src/FunctionApps/python/tests/IntakePipeline/fhir_test.py
@@ -49,7 +49,7 @@ def test_upload_bundle_to_fhir_server(mock_fhir_post):
             ],
         },
         "some-token",
-        "https://some-fhir-url"
+        "https://some-fhir-url",
     )
 
     mock_fhir_post.assert_called_with(


### PR DESCRIPTION
# Description
This PR does two primary things:  
1. It modifies the `upload_bundle_to_fhir_server` function to no longer maintain its own access token using the credential manager. Instead, both the access token and the FHIR URL are passed into the function by the orchestrator. Tests were updated to reflect this.
2. Expands the coverage of the pipeline tests to also ensure the pipeline works for invalid messages. 

# Test Plan
All tests pass when running `python -m pytest` and the code has been run locally to ensure that changes to `upload_bundle_to_fhir_server` didn't cause any obvious errors. The code appears to be working at a surface level as it was before the change.

# Feedback Requested
Nothing specific. The changes mentioned in (1) are a result of feedback left in PR#86, and changes in (2) seem straightforward.