### PR TITLE
Error handling to ignore observations without a key of value 'code'.

### DIFF
--- a/src/FunctionApps/python/GenerateCSVs/elr.py
+++ b/src/FunctionApps/python/GenerateCSVs/elr.py
@@ -13,7 +13,10 @@ def extract_loinc_lab(observation: dict) -> List[str]:
     If yes, collect the relevant lab code, test result, and test
     date into a list.
     """
-    code = observation["code"]["coding"][0]
+    try:
+        code = observation["code"]["coding"][0]
+    except KeyError:
+        return []
     if "loinc" in code["system"] and "valueCodeableConcept" in observation:
         obs_date = observation.get("effectiveDateTime")
         try:


### PR DESCRIPTION
Simple addition of some error handling. We should keep in mind that the rows in the ELR CSV are:

1. A mixture of ELR results and other observations resources.
2. Not necessarily all ELR results.
3. Not all observation resources.