### PR TITLE
Back out capture of detailed error info in logs

### DIFF
--- a/src/FunctionApps/python/IntakePipeline/conversion.py
+++ b/src/FunctionApps/python/IntakePipeline/conversion.py
@@ -157,42 +157,10 @@ def convert_message_to_fhir(
 
     if response.status_code != 200:
 
-        error_info = ""
-
-        # Try to parse the non-success response as OperationOutcome FHIR JSON
-        try:
-            response_json = response.json()
-
-            logging.info("non-200 response from fhir converter: " + str(response_json))
-
-            # If it's FHIR, unpack the response
-            if response_json["resourceType"] == "OperationOutcome":
-                for issue in response_json["issue"]:
-                    issue_severity = issue.get("severity")
-                    issue_code = issue.get("code")
-                    issue_diagnostics = issue.get("diagnostics")
-                    single_error_info = (
-                        f"Error processing: {filename}  "
-                        + f"HTTP Code: {response.status_code}  "
-                        + f"FHIR Severity: {issue_severity}  "
-                        + f"Code: {issue_code}  "
-                        + f"Diagnostics: {issue_diagnostics}"
-                    )
-                    if error_info == "":
-                        error_info = single_error_info
-                    else:
-                        error_info += "\n\t" + single_error_info
-
-        except Exception:
-            # ; If an exception occurs while parsing FHIR JSON,
-            # Log the full response content
-            decoded_response = response.content.decode("utf-8")
-            error_info = (
-                f"HTTP Code: {response.status_code}, "
-                + f"Response Content {decoded_response}"
-            )
-
-        logging.error(f"Error during $convert-data -- {error_info}")
+        logging.error(
+            f"HTTP {response.status_code} code encountered "
+            + f"on $convert-data for {filename}"
+        )
 
         return {}
 

--- a/src/FunctionApps/python/tests/IntakePipeline/conversion_test.py
+++ b/src/FunctionApps/python/tests/IntakePipeline/conversion_test.py
@@ -191,8 +191,7 @@ def test_log_fhir_operationoutcome(mock_log, mock_fhir_post):
     )
 
     mock_log.assert_called_with(
-        "Error during $convert-data -- Error processing: some-filename-0  "
-        + "HTTP Code: 400  FHIR Severity: fatal  Code: code-invalid  Diagnostics: None"
+        "HTTP 400 code encountered on $convert-data for some-filename-0"
     )
 
     assert response == {}
@@ -233,7 +232,7 @@ def test_log_generic_error(mock_log, mock_fhir_post):
     )
 
     mock_log.assert_called_with(
-        "Error during $convert-data -- HTTP Code: 400, Response Content some-error"
+        "HTTP 400 code encountered on $convert-data for some-filename-0"
     )
 
     assert response == {}


### PR DESCRIPTION
Errors coming from conversion failures may contain PII.  Removing the logging functionality until we can find a safe way to record the error information.