### PR TITLE
Secure log output

### DIFF
--- a/src/FunctionApps/python/IntakePipeline/__init__.py
+++ b/src/FunctionApps/python/IntakePipeline/__init__.py
@@ -65,7 +65,7 @@ def run_pipeline(
                 valid_output_path,
                 f"{message_mappings['filename']}.fhir",
                 message_mappings["bundle_type"],
-                bundle=bundle,
+                message_json=bundle,
             )
         except ResourceExistsError:
             logging.warning(
@@ -82,7 +82,7 @@ def run_pipeline(
                 invalid_output_path,
                 f"{message_mappings['filename']}.{message_mappings['file_suffix']}",
                 message_mappings["bundle_type"],
-                message=json.dumps(message),
+                message=message,
             )
         except ResourceExistsError:
             logging.warning(
@@ -97,7 +97,7 @@ def run_pipeline(
                 f"{message_mappings['filename']}.{message_mappings['file_suffix']}"
                 + ".convert-resp",
                 message_mappings["bundle_type"],
-                bundle=response,
+                message_json=response,
             )
         except ResourceExistsError:
             logging.warning(

--- a/src/FunctionApps/python/IntakePipeline/conversion.py
+++ b/src/FunctionApps/python/IntakePipeline/conversion.py
@@ -156,11 +156,11 @@ def convert_message_to_fhir(
     )
 
     if response.status_code != 200:
-        logging.error(f"Error code {str(response.status_code)} received while processing {filename}")
+        logging.error(f"HTTP {str(response.status_code)} code encountered on $convert-data for {filename}")
 
         error_info = {
             "http_status_code": response.status_code,
-            "response content": response.text,
+            "response_content": response.text,
         }
 
         return error_info

--- a/src/FunctionApps/python/IntakePipeline/conversion.py
+++ b/src/FunctionApps/python/IntakePipeline/conversion.py
@@ -157,42 +157,10 @@ def convert_message_to_fhir(
 
     if response.status_code != 200:
 
-        error_info = ""
-
-        # Try to parse the non-success response as OperationOutcome FHIR JSON
-        try:
-            response_json = response.json()
-
-            logging.info("non-200 response from fhir converter: " + str(response_json))
-
-            # If it's FHIR, unpack the response
-            if response_json["resourceType"] == "OperationOutcome":
-                for issue in response_json["issue"]:
-                    issue_severity = issue.get("severity")
-                    issue_code = issue.get("code")
-                    issue_diagnostics = issue.get("diagnostics")
-                    single_error_info = (
-                        f"Error processing: {filename}  "
-                        + f"HTTP Code: {response.status_code}  "
-                        + f"FHIR Severity: {issue_severity}  "
-                        + f"Code: {issue_code}  "
-                        + f"Diagnostics: {issue_diagnostics}"
-                    )
-                    if error_info == "":
-                        error_info = single_error_info
-                    else:
-                        error_info += "\n\t" + single_error_info
-
-        except Exception:
-            # ; If an exception occurs while parsing FHIR JSON,
-            # Log the full response content
-            decoded_response = response.content.decode("utf-8")
-            error_info = (
-                f"HTTP Code: {response.status_code}, "
-                + f"Response Content {decoded_response}"
-            )
-
-        logging.error(f"Error during $convert-data -- {error_info}")
+        logging.error(
+            f"HTTP {response.status_code} code encountered "
+            + f"on $convert-data for {filename}"
+        )
 
         return {}
 

--- a/src/FunctionApps/python/IntakePipeline/conversion.py
+++ b/src/FunctionApps/python/IntakePipeline/conversion.py
@@ -156,12 +156,13 @@ def convert_message_to_fhir(
     )
 
     if response.status_code != 200:
+        logging.error("Error code " + str(response.status_code) + " received while ")
 
-        logging.error(
-            f"HTTP {response.status_code} code encountered "
-            + f"on $convert-data for {filename}"
-        )
+        error_info = {
+            "http_status_code": response.status_code,
+            "response content": response.text,
+        }
 
-        return {}
+        return error_info
 
     return response.json()

--- a/src/FunctionApps/python/IntakePipeline/conversion.py
+++ b/src/FunctionApps/python/IntakePipeline/conversion.py
@@ -156,7 +156,7 @@ def convert_message_to_fhir(
     )
 
     if response.status_code != 200:
-        logging.error("Error code " + str(response.status_code) + " received while ")
+        logging.error(f"Error code {str(response.status_code)} received while processing {filename}")
 
         error_info = {
             "http_status_code": response.status_code,

--- a/src/FunctionApps/python/IntakePipeline/conversion.py
+++ b/src/FunctionApps/python/IntakePipeline/conversion.py
@@ -156,7 +156,10 @@ def convert_message_to_fhir(
     )
 
     if response.status_code != 200:
-        logging.error(f"HTTP {str(response.status_code)} code encountered on $convert-data for {filename}")
+        logging.error(
+            f"HTTP {str(response.status_code)} code encountered on"
+            + f" $convert-data for {filename}"
+        )
 
         error_info = {
             "http_status_code": response.status_code,

--- a/src/FunctionApps/python/IntakePipeline/fhir.py
+++ b/src/FunctionApps/python/IntakePipeline/fhir.py
@@ -28,7 +28,7 @@ def store_data(
     prefix: str,
     filename: str,
     bundle_type: str,
-    bundle: dict = None,
+    message_json: dict = None,
     message: str = None,
 ) -> None:
     """
@@ -37,8 +37,8 @@ def store_data(
     """
     client = get_blob_client(container_url)
     blob = client.get_blob_client(str(pathlib.Path(prefix) / bundle_type / filename))
-    if bundle is not None:
-        blob.upload_blob(json.dumps(bundle).encode("utf-8"), overwrite=True)
+    if message_json is not None:
+        blob.upload_blob(json.dumps(message_json).encode("utf-8"), overwrite=True)
     elif message is not None:
         blob.upload_blob(bytes(message, "utf-8"), overwrite=True)
 

--- a/src/FunctionApps/python/IntakePipeline/transform.py
+++ b/src/FunctionApps/python/IntakePipeline/transform.py
@@ -67,7 +67,7 @@ def transform_bundle(client: us_street.Client, bundle: dict) -> None:
                 raw_phones.append(telecom["value"])
                 std_phones.append(transformed_phone)
                 telecom["value"] = transformed_phone
-        any_diffs = any(
+        any_diffs = len(raw_phones) != len(std_phones) or any(
             [raw_phones[i] != std_phones[i] for i in range(len(raw_phones))]
         )
         patient["extension"].append(
@@ -109,7 +109,7 @@ def transform_bundle(client: us_street.Client, bundle: dict) -> None:
                         ],
                     }
                 )
-        any_dffs = any(
+        any_dffs = (len(raw_addresses) != len(std_addresses)) or any(
             [raw_addresses[i] != std_addresses[i] for i in range(len(raw_addresses))]
         )
         patient["extension"].append(

--- a/src/FunctionApps/python/tests/IntakePipeline/conversion_test.py
+++ b/src/FunctionApps/python/tests/IntakePipeline/conversion_test.py
@@ -145,14 +145,15 @@ def test_log_generic_error(mock_log, mock_fhir_post):
         "HTTP 400 code encountered on $convert-data for some-filename-0"
     )
 
-    assert response == {"http_status_code": 400,
-        "response_content": "some-error"}
+    assert response == {"http_status_code": 400, "response_content": "some-error"}
 
 
 @mock.patch("requests.post")
 @mock.patch("logging.error")
 def test_log_special_char_error(mock_log, mock_fhir_post):
-    mock_fhir_post.return_value = mock.Mock(status_code=400, text="some-error with \" special \' characters \n")
+    mock_fhir_post.return_value = mock.Mock(
+        status_code=400, text="some-error with \" special ' characters \n"
+    )
 
     message = "MSH|blah|foo|test\nPID|some^text|blah\nOBX|foo||||bar^baz&foobar"
 
@@ -187,8 +188,11 @@ def test_log_special_char_error(mock_log, mock_fhir_post):
         "HTTP 400 code encountered on $convert-data for some-filename-0"
     )
 
-    assert response == {"http_status_code": 400,
-        "response_content": "some-error with \" special \' characters \n"}
+    assert response == {
+        "http_status_code": 400,
+        "response_content": "some-error with \" special ' characters \n",
+    }
+
 
 def test_get_filetype_mappings_valid_files():
     TEST_STRING1 = "decrypted/ELR/some-file.hl7"

--- a/src/FunctionApps/python/tests/IntakePipeline/conversion_test.py
+++ b/src/FunctionApps/python/tests/IntakePipeline/conversion_test.py
@@ -155,6 +155,15 @@ def test_log_generic_error(mock_log, mock_fhir_post):
     mock_fhir_post.return_value = mock.Mock(status_code=400, text="some-error")
 
     message = "MSH|blah|foo|test\nPID|some^text|blah\nOBX|foo||||bar^baz&foobar"
+    convert_message_to_fhir(
+        message,
+        "some-filename-0",
+        "Hl7v2",
+        "VXU_V04",
+        "microsofthealth/fhirconverter:default",
+        "some-token",
+        "some-fhir-url",
+    )
 
     mock_fhir_post.assert_called_with(
         url="some-fhir-url/$convert-data",

--- a/src/FunctionApps/python/tests/IntakePipeline/conversion_test.py
+++ b/src/FunctionApps/python/tests/IntakePipeline/conversion_test.py
@@ -191,8 +191,7 @@ def test_log_fhir_operationoutcome(mock_log, mock_fhir_post):
     )
 
     mock_log.assert_called_with(
-        "Error during $convert-data -- Error processing: some-filename-0  "
-        + "HTTP Code: 400  FHIR Severity: fatal  Code: code-invalid  Diagnostics: None"
+        "HTTP 400 code encountered on $convert-data for some-filename-0"
     )
 
     assert response == {}
@@ -233,7 +232,7 @@ def test_log_generic_error(mock_log, mock_fhir_post):
     )
 
     mock_log.assert_called_with(
-        "Error during $convert-data -- HTTP Code: 400, Response Content some-error"
+        "HTTP 400 code encountered on $convert-data for some-filename-0"
     )
 
     assert response == {}

--- a/src/FunctionApps/python/tests/IntakePipeline/pipeline_test.py
+++ b/src/FunctionApps/python/tests/IntakePipeline/pipeline_test.py
@@ -160,7 +160,7 @@ def test_pipeline_partial_invalid_message(
         {"resourceType": "Bundle",
     "entry": [{"hello": "world"}]},
         {"http_status_code": 400,
-        "response_content": "some-error"},
+        "response_content": "\"some-error\""},
         {"resourceType": "Bundle",
     "entry": [{"hello": "world"}]},
         {"resourceType": "Bundle",
@@ -287,7 +287,7 @@ def test_pipeline_partial_invalid_message(
                 "some-filename-2.hl7.convert-resp",
                 "VXU",
                 message_json={"http_status_code": 400,
-        "response_content": "some-error"},
+        "response_content": "\"some-error\""},
             ),
             mock.call(
                 "some-url",

--- a/src/FunctionApps/python/tests/IntakePipeline/pipeline_test.py
+++ b/src/FunctionApps/python/tests/IntakePipeline/pipeline_test.py
@@ -50,8 +50,10 @@ def test_pipeline_valid_message(
     patched_patient_id,
     patched_transform,
 ):
-    patched_converter.return_value = {"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]}
+    patched_converter.return_value = {
+        "resourceType": "Bundle",
+        "entry": [{"hello": "world"}],
+    }
 
     patched_geocoder = mock.Mock()
     patched_get_geocoder.return_value = patched_geocoder
@@ -68,19 +70,23 @@ def test_pipeline_valid_message(
         access_token="some-token",
         fhir_url="some-fhir-url",
     )
-    patched_transform.assert_called_with(patched_geocoder, {"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]})
-    patched_patient_id.assert_called_with(TEST_ENV["HASH_SALT"], {"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]})
-    patched_upload.assert_called_with({"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]}, "some-token", "some-fhir-url")
+    patched_transform.assert_called_with(
+        patched_geocoder, {"resourceType": "Bundle", "entry": [{"hello": "world"}]}
+    )
+    patched_patient_id.assert_called_with(
+        TEST_ENV["HASH_SALT"], {"resourceType": "Bundle", "entry": [{"hello": "world"}]}
+    )
+    patched_upload.assert_called_with(
+        {"resourceType": "Bundle", "entry": [{"hello": "world"}]},
+        "some-token",
+        "some-fhir-url",
+    )
     patched_store.assert_called_with(
         "some-url",
         "output/valid/path",
         f"{MESSAGE_MAPPINGS['filename']}.fhir",
         MESSAGE_MAPPINGS["bundle_type"],
-        message_json={"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]},
+        message_json={"resourceType": "Bundle", "entry": [{"hello": "world"}]},
     )
 
 
@@ -99,8 +105,10 @@ def test_pipeline_invalid_message(
     patched_patient_id,
     patched_transform,
 ):
-    patched_converter.return_value = {"http_status_code": 400,
-        "response_content": "some-error"}
+    patched_converter.return_value = {
+        "http_status_code": 400,
+        "response_content": "some-error",
+    }
 
     patched_geocoder = mock.Mock()
     patched_get_geocoder.return_value = patched_geocoder
@@ -120,21 +128,26 @@ def test_pipeline_invalid_message(
     patched_transform.assert_not_called()
     patched_patient_id.assert_not_called()
     patched_upload.assert_not_called()
-    patched_store.assert_has_calls([
-        mock.call("some-url",
-        "output/invalid/path",
-        f"{MESSAGE_MAPPINGS['filename']}.hl7",
-        MESSAGE_MAPPINGS["bundle_type"],
-        message="MSH|Hello World",
-        ),
-        mock.call("some-url",
-        "output/invalid/path",
-        f"{MESSAGE_MAPPINGS['filename']}.hl7.convert-resp",
-        MESSAGE_MAPPINGS["bundle_type"],
-        message_json={"http_status_code": 400,
-        "response_content": "some-error"},
-        )
-    ]
+    patched_store.assert_has_calls(
+        [
+            mock.call(
+                "some-url",
+                "output/invalid/path",
+                f"{MESSAGE_MAPPINGS['filename']}.hl7",
+                MESSAGE_MAPPINGS["bundle_type"],
+                message="MSH|Hello World",
+            ),
+            mock.call(
+                "some-url",
+                "output/invalid/path",
+                f"{MESSAGE_MAPPINGS['filename']}.hl7.convert-resp",
+                MESSAGE_MAPPINGS["bundle_type"],
+                message_json={
+                    "http_status_code": 400,
+                    "response_content": "some-error",
+                },
+            ),
+        ]
     )
 
 
@@ -155,16 +168,11 @@ def test_pipeline_partial_invalid_message(
     partial_failure_message,
 ):
     patched_converter.side_effect = [
-        {"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]},
-        {"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]},
-        {"http_status_code": 400,
-        "response_content": "\"some-error\""},
-        {"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]},
-        {"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]},
+        {"resourceType": "Bundle", "entry": [{"hello": "world"}]},
+        {"resourceType": "Bundle", "entry": [{"hello": "world"}]},
+        {"http_status_code": 400, "response_content": '"some-error"'},
+        {"resourceType": "Bundle", "entry": [{"hello": "world"}]},
+        {"resourceType": "Bundle", "entry": [{"hello": "world"}]},
     ]
 
     patched_geocoder = mock.Mock()
@@ -263,16 +271,14 @@ def test_pipeline_partial_invalid_message(
                 "output/valid/path",
                 "some-filename-0.fhir",
                 "VXU",
-                message_json={"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]},
+                message_json={"resourceType": "Bundle", "entry": [{"hello": "world"}]},
             ),
             mock.call(
                 "some-url",
                 "output/valid/path",
                 "some-filename-1.fhir",
                 "VXU",
-                message_json={"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]},
+                message_json={"resourceType": "Bundle", "entry": [{"hello": "world"}]},
             ),
             mock.call(
                 "some-url",
@@ -286,24 +292,24 @@ def test_pipeline_partial_invalid_message(
                 "output/invalid/path",
                 "some-filename-2.hl7.convert-resp",
                 "VXU",
-                message_json={"http_status_code": 400,
-        "response_content": "\"some-error\""},
+                message_json={
+                    "http_status_code": 400,
+                    "response_content": '"some-error"',
+                },
             ),
             mock.call(
                 "some-url",
                 "output/valid/path",
                 "some-filename-3.fhir",
                 "VXU",
-                message_json={"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]},
+                message_json={"resourceType": "Bundle", "entry": [{"hello": "world"}]},
             ),
             mock.call(
                 "some-url",
                 "output/valid/path",
                 "some-filename-4.fhir",
                 "VXU",
-                message_json={"resourceType": "Bundle",
-    "entry": [{"hello": "world"}]},
+                message_json={"resourceType": "Bundle", "entry": [{"hello": "world"}]},
             ),
         ]
     )

--- a/src/FunctionApps/python/tests/IntakePipeline/pipeline_test.py
+++ b/src/FunctionApps/python/tests/IntakePipeline/pipeline_test.py
@@ -50,7 +50,8 @@ def test_pipeline_valid_message(
     patched_patient_id,
     patched_transform,
 ):
-    patched_converter.return_value = {"hello": "world"}
+    patched_converter.return_value = {"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]}
 
     patched_geocoder = mock.Mock()
     patched_get_geocoder.return_value = patched_geocoder
@@ -67,15 +68,19 @@ def test_pipeline_valid_message(
         access_token="some-token",
         fhir_url="some-fhir-url",
     )
-    patched_transform.assert_called_with(patched_geocoder, {"hello": "world"})
-    patched_patient_id.assert_called_with(TEST_ENV["HASH_SALT"], {"hello": "world"})
-    patched_upload.assert_called_with({"hello": "world"}, "some-token", "some-fhir-url")
+    patched_transform.assert_called_with(patched_geocoder, {"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]})
+    patched_patient_id.assert_called_with(TEST_ENV["HASH_SALT"], {"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]})
+    patched_upload.assert_called_with({"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]}, "some-token", "some-fhir-url")
     patched_store.assert_called_with(
         "some-url",
         "output/valid/path",
         f"{MESSAGE_MAPPINGS['filename']}.fhir",
         MESSAGE_MAPPINGS["bundle_type"],
-        bundle={"hello": "world"},
+        message_json={"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]},
     )
 
 
@@ -94,7 +99,8 @@ def test_pipeline_invalid_message(
     patched_patient_id,
     patched_transform,
 ):
-    patched_converter.return_value = {}
+    patched_converter.return_value = {"http_status_code": 400,
+        "response_content": "some-error"}
 
     patched_geocoder = mock.Mock()
     patched_get_geocoder.return_value = patched_geocoder
@@ -114,12 +120,21 @@ def test_pipeline_invalid_message(
     patched_transform.assert_not_called()
     patched_patient_id.assert_not_called()
     patched_upload.assert_not_called()
-    patched_store.assert_called_with(
-        "some-url",
+    patched_store.assert_has_calls([
+        mock.call("some-url",
         "output/invalid/path",
         f"{MESSAGE_MAPPINGS['filename']}.hl7",
         MESSAGE_MAPPINGS["bundle_type"],
         message="MSH|Hello World",
+        ),
+        mock.call("some-url",
+        "output/invalid/path",
+        f"{MESSAGE_MAPPINGS['filename']}.hl7.convert-resp",
+        MESSAGE_MAPPINGS["bundle_type"],
+        message_json={"http_status_code": 400,
+        "response_content": "some-error"},
+        )
+    ]
     )
 
 
@@ -140,11 +155,16 @@ def test_pipeline_partial_invalid_message(
     partial_failure_message,
 ):
     patched_converter.side_effect = [
-        {"hello": "world"},
-        {"hello": "world"},
-        {},
-        {"hello": "world"},
-        {"hello": "world"},
+        {"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]},
+        {"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]},
+        {"http_status_code": 400,
+        "response_content": "some-error"},
+        {"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]},
+        {"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]},
     ]
 
     patched_geocoder = mock.Mock()
@@ -243,14 +263,16 @@ def test_pipeline_partial_invalid_message(
                 "output/valid/path",
                 "some-filename-0.fhir",
                 "VXU",
-                bundle={"hello": "world"},
+                message_json={"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]},
             ),
             mock.call(
                 "some-url",
                 "output/valid/path",
                 "some-filename-1.fhir",
                 "VXU",
-                bundle={"hello": "world"},
+                message_json={"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]},
             ),
             mock.call(
                 "some-url",
@@ -261,17 +283,27 @@ def test_pipeline_partial_invalid_message(
             ),
             mock.call(
                 "some-url",
+                "output/invalid/path",
+                "some-filename-2.hl7.convert-resp",
+                "VXU",
+                message_json={"http_status_code": 400,
+        "response_content": "some-error"},
+            ),
+            mock.call(
+                "some-url",
                 "output/valid/path",
                 "some-filename-3.fhir",
                 "VXU",
-                bundle={"hello": "world"},
+                message_json={"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]},
             ),
             mock.call(
                 "some-url",
                 "output/valid/path",
                 "some-filename-4.fhir",
                 "VXU",
-                bundle={"hello": "world"},
+                message_json={"resourceType": "Bundle",
+    "entry": [{"hello": "world"}]},
             ),
         ]
     )


### PR DESCRIPTION
## Summary
Previously, we were sending function app messages to the standard logs, which ended up stored locally on the functionapp's service app (linux container).  This wasn't OK, because the output could contain PII, and the log file location is unencrypted.  

Now, we are returning the HTTP status code and accompanying return value.  The code that calls the conversion function stores the response information in a (secure) blob location.  

## Fixes
Previously, if the number of address elements from an incoming element did not equal the number of elements in the standardized address, it resulted in a address key error.  This has been fixed.

## Testing
Tests have been updated to reflect that successful responses should contain a FHIR bundle (resourceType = "Bundle").  The error response is no longer has special handling for OperationOutcome, so corresponding tests have been removed.