### PR TITLE
Give ADF access to bronze-additional-records container

### DIFF
--- a/operations/app/terraform/modules/storage/data.tf
+++ b/operations/app/terraform/modules/storage/data.tf
@@ -9,7 +9,7 @@ data "azuread_service_principal" "pitest" {
 # storage account data containers and permissions
 # see docs/security/data-access.md for additional notes
 locals {
-  data_containers = ["bronze", "silver", "gold"]
+  data_containers = ["bronze", "bronze-additional-records", "silver", "gold"]
   data_ace_access = [
     { permissions = "---", id = null, type = "other", scope = "access" },
     { permissions = "---", id = null, type = "other", scope = "default" },


### PR DESCRIPTION
# Description
In an effort to bring in the new data that VA is providing, we want to be able to point the Azure Data Factory to the `bronze-additional-records` container. In the future, we'll likely want to point it back to `bronze` and ingest everything into a single storage container, but for now, it's probably best to keep the new data separate.