### PR TITLE
Add directory looping for bronze-additional-records container

### DIFF
--- a/operations/app/terraform/modules/storage/data.tf
+++ b/operations/app/terraform/modules/storage/data.tf
@@ -9,7 +9,7 @@ data "azuread_service_principal" "pitest" {
 # storage account data containers and permissions
 # see docs/security/data-access.md for additional notes
 locals {
-  data_containers = ["bronze", "silver", "gold"]
+  data_containers = ["bronze", "bronze-additional-records", "silver", "gold"]
   data_ace_access = [
     { permissions = "---", id = null, type = "other", scope = "access" },
     { permissions = "---", id = null, type = "other", scope = "default" },

--- a/operations/app/terraform/modules/storage/data.tf
+++ b/operations/app/terraform/modules/storage/data.tf
@@ -53,6 +53,28 @@ locals {
       }
     ]
   ]))
+  bronze_additional_records_root_dirs = [
+      "decrypted",
+      "raw"
+  ]
+  bronze_additional_records_sub_dirs = [
+    "",
+    "/eICR",
+    "/ELR",
+    "/OtherFiles",
+    "/VEDSS",
+    "/VIIS",
+    "/VXU"
+  ]
+  # Nested loop over both lists, and flatten the result.
+  bronze_additional_records_mapping = distinct(flatten([
+    for bronze_additional_records_root_dir in local.bronze_additional_records_root_dirs : [
+      for bronze_additional_records_sub_dir in local.bronze_additional_records_sub_dirs : {
+        bronze_additional_record_sub_dir  = bronze_additional_record_sub_dir
+        bronze_additional_record_root_dir = bronze_additional_record_root_dir
+      }
+    ]
+  ]))
   silver_root_dirs = ["temp"]
   silver_sub_dirs = [
     ""


### PR DESCRIPTION
# Description
The `data.tf` file, in addition to specifying the permissions for the storage containers, loops through the subdirectories of each container, which [PR#110](https://github.com/CDCgov/prime-public-health-data-infrastructure/pull/110) missed. Josiah has mentioned that this might not be necessary, but for the sake of verbosity and completeness it makes sense to add it in.