### PR TITLE
Point IntakePipeline to load phdi_building_blocks from main.

### DIFF
--- a/src/FunctionApps/python/requirements.txt
+++ b/src/FunctionApps/python/requirements.txt
@@ -4,7 +4,7 @@ azure-functions
 azure-identity
 azure-storage-blob
 hl7
-phdi_building_blocks @ git+https://github.com/CDCgov/prime-public-health-data-infrastructure@dan/TEMP-phdi-building-blocks#subdirectory=src/lib/phdi-building-blocks
+phdi_building_blocks @ git+https://github.com/CDCgov/prime-public-health-data-infrastructure@main#subdirectory=src/lib/phdi-building-blocks
 requests
 smartystreets_python_sdk
 urllib3


### PR DESCRIPTION
Now that #109 has been merged we can point the path used in `IntakePipeline` to load `phdi_building_blocks` `back to main`.