### PR TITLE
Allow specifying container during export

### DIFF
--- a/docs/security/data-access.md
+++ b/docs/security/data-access.md
@@ -10,7 +10,7 @@ Storage account containers and directories are managed by Terraform with ACL per
 `operations/app/terraform/modules/storage/data.tf`:
 ```sh
 locals {
-  data_containers = ["bronze", "silver", "gold"]
+  data_containers = ["bronze", "bronze-additional-records", "fhir-export", "silver", "gold"]
   data_ace_access = [
     { permissions = "---", id = null, type = "other", scope = "access" },
     { permissions = "---", id = null, type = "other", scope = "default" },

--- a/operations/app/terraform/modules/storage/data.tf
+++ b/operations/app/terraform/modules/storage/data.tf
@@ -9,7 +9,7 @@ data "azuread_service_principal" "pitest" {
 # storage account data containers and permissions
 # see docs/security/data-access.md for additional notes
 locals {
-  data_containers = ["bronze", "bronze-additional-records", "silver", "gold"]
+  data_containers = ["bronze", "bronze-additional-records", "fhir-export", "silver", "gold"]
   data_ace_access = [
     { permissions = "---", id = null, type = "other", scope = "access" },
     { permissions = "---", id = null, type = "other", scope = "default" },

--- a/src/FunctionApps/python/tests/FhirServerExport/test_main.py
+++ b/src/FunctionApps/python/tests/FhirServerExport/test_main.py
@@ -26,7 +26,9 @@ def test_main(mock_get_access_token, mock_export, mock_download):
         "type": "",
     }
 
-    mock_get_access_token.return_value = "some-token"
+    mock_access_token = mock.Mock()
+    mock_access_token.token = "some-token"
+    mock_get_access_token.return_value = mock_access_token
 
     export_return_value = {
         "output": [
@@ -65,6 +67,7 @@ def test_main(mock_get_access_token, mock_export, mock_download):
         export_scope="",
         since="",
         resource_type="",
+        container="",
         poll_step=0.1,
         poll_timeout=1.0,
     )

--- a/src/lib/phdi-building-blocks/tests/test_fhir.py
+++ b/src/lib/phdi-building-blocks/tests/test_fhir.py
@@ -259,6 +259,17 @@ def test_compose_export_url():
         + "&_type=Patient,Observation"
     )
     assert (
+        _compose_export_url(
+            fhir_url,
+            "Patient",
+            "2022-01-01T00:00:00Z",
+            "Patient,Observation",
+            "some-container",
+        )
+        == f"{fhir_url}/Patient/$export?_since=2022-01-01T00:00:00Z"
+        + "&_type=Patient,Observation&_container=some-container"
+    )
+    assert (
         _compose_export_url(fhir_url, "Patient", None, "Patient,Observation")
         == f"{fhir_url}/Patient/$export?_type=Patient,Observation"
     )


### PR DESCRIPTION
# Summary
Update FHIR export to specify a target container to which export files are written.

Additional changes
* Fix how access token is passed to export function
* Improve logging