### PR TITLE
Specify container on export

### DIFF
--- a/src/FunctionApps/python/tests/FhirServerExport/test_main.py
+++ b/src/FunctionApps/python/tests/FhirServerExport/test_main.py
@@ -26,7 +26,9 @@ def test_main(mock_get_access_token, mock_export, mock_download):
         "type": "",
     }
 
-    mock_get_access_token.return_value = "some-token"
+    mock_access_token = mock.Mock()
+    mock_access_token.token = "some-token"
+    mock_get_access_token.return_value = mock_access_token
 
     export_return_value = {
         "output": [
@@ -65,6 +67,7 @@ def test_main(mock_get_access_token, mock_export, mock_download):
         export_scope="",
         since="",
         resource_type="",
+        container="",
         poll_step=0.1,
         poll_timeout=1.0,
     )

--- a/src/lib/phdi-building-blocks/tests/test_fhir.py
+++ b/src/lib/phdi-building-blocks/tests/test_fhir.py
@@ -259,6 +259,17 @@ def test_compose_export_url():
         + "&_type=Patient,Observation"
     )
     assert (
+        _compose_export_url(
+            fhir_url,
+            "Patient",
+            "2022-01-01T00:00:00Z",
+            "Patient,Observation",
+            "some-container",
+        )
+        == f"{fhir_url}/Patient/$export?_since=2022-01-01T00:00:00Z"
+        + "&_type=Patient,Observation&_container=some-container"
+    )
+    assert (
         _compose_export_url(fhir_url, "Patient", None, "Patient,Observation")
         == f"{fhir_url}/Patient/$export?_type=Patient,Observation"
     )


### PR DESCRIPTION
# Summary
Update FHIR export to specify a target container to which export files are written.

Additional changes
* Fix how access token is passed to export function
* Improve logging
* Update terraform - add new fhir-export container