### PR TITLE
Configure container in functionapp

### DIFF
--- a/docs/security/data-access.md
+++ b/docs/security/data-access.md
@@ -10,7 +10,7 @@ Storage account containers and directories are managed by Terraform with ACL per
 `operations/app/terraform/modules/storage/data.tf`:
 ```sh
 locals {
-  data_containers = ["bronze", "bronze-additional-records", "fhir-export", "silver", "gold"]
+  data_containers = ["bronze", "bronze-additional-records", "fhir-exports", "silver", "gold"]
   data_ace_access = [
     { permissions = "---", id = null, type = "other", scope = "access" },
     { permissions = "---", id = null, type = "other", scope = "default" },

--- a/docs/security/data-access.md
+++ b/docs/security/data-access.md
@@ -10,7 +10,7 @@ Storage account containers and directories are managed by Terraform with ACL per
 `operations/app/terraform/modules/storage/data.tf`:
 ```sh
 locals {
-  data_containers = ["bronze", "silver", "gold"]
+  data_containers = ["bronze", "bronze-additional-records", "fhir-export", "silver", "gold"]
   data_ace_access = [
     { permissions = "---", id = null, type = "other", scope = "access" },
     { permissions = "---", id = null, type = "other", scope = "default" },

--- a/operations/app/terraform/modules/storage/data.tf
+++ b/operations/app/terraform/modules/storage/data.tf
@@ -9,7 +9,7 @@ data "azuread_service_principal" "pitest" {
 # storage account data containers and permissions
 # see docs/security/data-access.md for additional notes
 locals {
-  data_containers = ["bronze", "bronze-additional-records", "silver", "gold"]
+  data_containers = ["bronze", "bronze-additional-records", "fhir-export", "silver", "gold"]
   data_ace_access = [
     { permissions = "---", id = null, type = "other", scope = "access" },
     { permissions = "---", id = null, type = "other", scope = "default" },

--- a/operations/app/terraform/modules/storage/data.tf
+++ b/operations/app/terraform/modules/storage/data.tf
@@ -9,7 +9,7 @@ data "azuread_service_principal" "pitest" {
 # storage account data containers and permissions
 # see docs/security/data-access.md for additional notes
 locals {
-  data_containers = ["bronze", "bronze-additional-records", "fhir-export", "silver", "gold"]
+  data_containers = ["bronze", "bronze-additional-records", "fhir-exports", "silver", "gold"]
   data_ace_access = [
     { permissions = "---", id = null, type = "other", scope = "access" },
     { permissions = "---", id = null, type = "other", scope = "default" },

--- a/src/FunctionApps/python/FhirServerExport/README.md
+++ b/src/FunctionApps/python/FhirServerExport/README.md
@@ -12,6 +12,7 @@ The configuration values required to be set for the IntakePipeline function are 
 * `FHIR_URL`: the base url for the FHIR server used to persist FHIR objects
 * `FHIR_EXPORT_POLL_INTERVAL`: (default = 30) the number of seconds to wait between checks for the completion of an export.  This setting supports a decimal value.
 * `FHIR_EXPORT_POLL_TIMEOUT`: (default = 300) the number of seconds to wait for the completion of an export.  If the time extends beyond this interval, the function will return a timeout error.
+* `FHIR_EXPORT_CONTAINER`: (default = "fhir-exports") the name of the container that holds export runs (the service account is configured in the FHIR Server).  In order to create a new container for each export run, enter a value of `<none>`.  
 
 # Description
 This function provides a simplified client to the Azure implementation of the [HL7 Bulk Data Export](https://hl7.org/fhir/uv/bulkdata/export/index.html) specification.  The [Azure implementation](https://docs.microsoft.com/en-us/azure/healthcare-apis/fhir/export-data) follows the general guidance outlined by the spec, but is tied to Azure in that it stores exported files to Blob storage.  

--- a/src/FunctionApps/python/FhirServerExport/__init__.py
+++ b/src/FunctionApps/python/FhirServerExport/__init__.py
@@ -13,6 +13,10 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     poll_step = float(config.get_required_config("FHIR_EXPORT_POLL_INTERVAL", 30))
     poll_timeout = float(config.get_required_config("FHIR_EXPORT_POLL_TIMEOUT", 300))
 
+    container = config.get_required_config("FHIR_EXPORT_CONTAINER", "fhir-exports")
+    if container == "<none>":
+        container = ""
+
     cred_manager = fhir.AzureFhirserverCredentialManager(fhir_url=fhir_url)
 
     access_token = cred_manager.get_access_token()
@@ -24,7 +28,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
             export_scope=req.params.get("export_scope", ""),
             since=req.params.get("since", ""),
             resource_type=req.params.get("type", ""),
-            container=req.params.get("container", ""),
+            container=container,
             poll_step=poll_step,
             poll_timeout=poll_timeout,
         )

--- a/src/FunctionApps/python/tests/FhirServerExport/test_main.py
+++ b/src/FunctionApps/python/tests/FhirServerExport/test_main.py
@@ -67,7 +67,7 @@ def test_main(mock_get_access_token, mock_export, mock_download):
         export_scope="",
         since="",
         resource_type="",
-        container="",
+        container="fhir-exports",
         poll_step=0.1,
         poll_timeout=1.0,
     )


### PR DESCRIPTION
* Rather than allowing the target container for export files to be specified as part of the export request, configure it in the function app serttings.
* Add new fhir-exports default export storage container to terraform
