### PR TITLE
Add GitHub Actions for deployment

### DIFF
--- a/.github/workflows/deployDev.yaml
+++ b/.github/workflows/deployDev.yaml
@@ -1,0 +1,36 @@
+name: Deploy Dev
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy_dev:
+    name: Deploy to prime-ingestion-dev
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./operations/app/terraform/vars/dev
+    steps:
+      - name: Check Out Changes
+        uses: actions/checkout@v2
+
+      - name: Login to Azure and Terraform
+        uses: ./.github/actions/az-tf
+        with:
+          sp-creds: ${{ secrets.SERVICE_PRINCIPAL_CREDS }}
+
+      - name: Allow GitHub runner access
+        run: |
+          RUNNER_IP="$(dig +short myip.opendns.com @resolver1.opendns.com)/32"
+          az keyvault network-rule add -n pidev-app-kv --ip-address "$RUNNER_IP" >/dev/null
+          echo "runner_ip=$RUNNER_IP" >> $GITHUB_ENV
+
+      - name: Deploy
+        run: |
+          terraform init
+          terraform apply -auto-approve -lock-timeout=30m
+
+      - name: Remove GitHub runner access
+        if: ${{ always() }}
+        run: az keyvault network-rule remove -n pidev-app-kv --ip-address "${{ env.runner_ip }}" >/dev/null

--- a/.github/workflows/deployTest.yaml
+++ b/.github/workflows/deployTest.yaml
@@ -1,0 +1,36 @@
+name: Deploy Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy_test:
+    name: Deploy to prime-ingestion-test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./operations/app/terraform/vars/test
+    steps:
+      - name: Check Out Changes
+        uses: actions/checkout@v2
+
+      - name: Login to Azure and Terraform
+        uses: ./.github/actions/az-tf
+        with:
+          sp-creds: ${{ secrets.SERVICE_PRINCIPAL_CREDS }}
+
+      - name: Allow GitHub runner access
+        run: |
+          RUNNER_IP="$(dig +short myip.opendns.com @resolver1.opendns.com)/32"
+          az keyvault network-rule add -n pitest-app-kv --ip-address "$RUNNER_IP" >/dev/null
+          echo "runner_ip=$RUNNER_IP" >> $GITHUB_ENV
+
+      - name: Deploy
+        run: |
+          terraform init
+          terraform apply -auto-approve -lock-timeout=30m
+
+      - name: Remove GitHub runner access
+        if: ${{ always() }}
+        run: az keyvault network-rule remove -n pitest-app-kv --ip-address "${{ env.runner_ip }}" >/dev/null


### PR DESCRIPTION
Resolves [this ticket](https://reportstream-service-request.clickup.com/t/29av3gn)

This PR creates two new GitHub Actions, one for deploying to `dev` and another for deploying to `test`. They are pretty simple, just logging into Azure/Terraform using the creds stored for CI, and running terraform apply. We will need to merge this PR before we can test running the actions, which will create the actions in [the UI here](https://github.com/CDCgov/prime-public-health-data-infrastructure/actions), then any further changes can be tested in further PRs before merging, since branches can be specified for existing actions.