### PR TITLE
Use github context to get current branch for testing workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies
         working-directory: ./src/FunctionApps/${{matrix.function-to-test}}
         run: |
-          pip install -U pip
+          git branch --show-current
           sed -i "\|prime-public-health-data-infrastructure@|s|main|$(git branch --show-current)|" requirements.txt
           pip install -r requirements.txt
           pip install pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,8 +58,7 @@ jobs:
       - name: Install dependencies
         working-directory: ./src/FunctionApps/${{matrix.function-to-test}}
         run: |
-          git branch --show-current
-          sed -i "\|prime-public-health-data-infrastructure@|s|main|$(git branch --show-current)|" requirements.txt
+          sed -i "\|prime-public-health-data-infrastructure@|s|main|${{ github.head_ref }}|" requirements.txt
           pip install -r requirements.txt
           pip install pytest
       - name: Run unit tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ./src/FunctionApps/${{matrix.function-to-test}}
         run: |
           pip install -U pip
-          sed -i "\|prime-public-health-data-infrastructure@|s|main|$GITHUB_HEAD_REF|" requirements.txt
+          sed -i "\|prime-public-health-data-infrastructure@|s|main|$(git branch --show-current)|" requirements.txt
           pip install -r requirements.txt
           pip install pytest
       - name: Run unit tests


### PR DESCRIPTION
Since $GITHUB_HEAD_REF is only available in pull requests, use the `github` [context object](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) to get the current branch instead for the testing workflow. I _think_ this should be available on the main branch as well, but we will have to merge to find out.