### PR TITLE
Ability to write schemas to CSV

### DIFF
--- a/src/lib/phdi-building-blocks/phdi_building_blocks/schemas.py
+++ b/src/lib/phdi-building-blocks/phdi_building_blocks/schemas.py
@@ -1,3 +1,4 @@
+import csv
 import pathlib
 import os
 import yaml
@@ -203,6 +204,15 @@ def write_schema_table(
         writer.write_table(table=table)
         return writer
 
+    if file_format == "csv":
+        keys = data[0].keys()
+        new_file = False if os.path.isfile(output_file_name) else True
+        with open(output_file_name, 'a', newline='') as output_file:
+            dict_writer = csv.DictWriter(output_file, keys)
+            if new_file:
+                dict_writer.writeheader()
+            dict_writer.writerows(data)
+
 
 def print_schema_summary(
     schema_directory: pathlib.Path,
@@ -218,6 +228,7 @@ def print_schema_summary(
     """
 
     for (directory_path, _, file_names) in os.walk(schema_directory):
+        print('hi')
         for file_name in file_names:
             if file_name.endswith("parquet"):
                 # Read metadata from parquet file without loading the actual data.
@@ -230,3 +241,8 @@ def print_schema_summary(
                     df = parquet_table.to_pandas()
                     print(df.head())
                     print(df.info())
+            if file_name.endswith("csv"):
+                with open(file_name, 'r') as csv_file:
+                    reader = csv.reader(csv_file, dialect='excel')
+                    print(next(reader))
+                    return 'hi'

--- a/src/lib/phdi-building-blocks/phdi_building_blocks/schemas.py
+++ b/src/lib/phdi-building-blocks/phdi_building_blocks/schemas.py
@@ -226,9 +226,7 @@ def print_schema_summary(
     :param display_head: Print the head of each table when true. Note depending on the
     file format this may require reading large amounts of data into memory.
     """
-
     for (directory_path, _, file_names) in os.walk(schema_directory):
-        print('hi')
         for file_name in file_names:
             if file_name.endswith("parquet"):
                 # Read metadata from parquet file without loading the actual data.

--- a/src/lib/phdi-building-blocks/phdi_building_blocks/schemas.py
+++ b/src/lib/phdi-building-blocks/phdi_building_blocks/schemas.py
@@ -207,7 +207,7 @@ def write_schema_table(
     if file_format == "csv":
         keys = data[0].keys()
         new_file = False if os.path.isfile(output_file_name) else True
-        with open(output_file_name, 'a', newline='') as output_file:
+        with open(output_file_name, "a", newline="") as output_file:
             dict_writer = csv.DictWriter(output_file, keys)
             if new_file:
                 dict_writer.writeheader()
@@ -240,7 +240,7 @@ def print_schema_summary(
                     print(df.head())
                     print(df.info())
             if file_name.endswith("csv"):
-                with open(file_name, 'r') as csv_file:
-                    reader = csv.reader(csv_file, dialect='excel')
+                with open(file_name, "r") as csv_file:
+                    reader = csv.reader(csv_file, dialect="excel")
                     print(next(reader))
-                    return 'hi'
+                    return "hi"

--- a/src/lib/phdi-building-blocks/tests/test_schemas.py
+++ b/src/lib/phdi-building-blocks/tests/test_schemas.py
@@ -1,9 +1,6 @@
 import csv
-import io
 import json
 import os
-import sys
-import pytest
 import yaml
 import pathlib
 from unittest import mock
@@ -227,45 +224,50 @@ def test_write_schema_table_with_writer(patched_pa_table, patched_writer):
     writer.write_table.assert_called_with(table=table)
     assert len(patched_writer.call_args_list) == 0
 
+
 def test_write_schema_table_new_csv():
     data = [{"some_column": "some value", "some_other_column": "some other value"}]
-    output_file_name = 'create_new.csv'
+    output_file_name = "create_new.csv"
     file_format = "csv"
 
     if os.path.isfile(output_file_name):
         os.remove(output_file_name)
-    
+
     write_schema_table(data, output_file_name, file_format)
 
-    with open(output_file_name, 'r') as csv_file:
-        reader = csv.reader(csv_file, dialect='excel')
+    with open(output_file_name, "r") as csv_file:
+        reader = csv.reader(csv_file, dialect="excel")
         assert next(reader) == list(data[0].keys())
 
     os.remove(output_file_name)
 
+
 def test_write_schema_table_append_csv():
     data = [{"some_column": "some value", "some_other_column": "some other value"}]
-    output_file_name = 'append.csv';
+    output_file_name = "append.csv"
     file_format = "csv"
 
     if os.path.isfile(output_file_name):
         os.remove(output_file_name)
-    
+
     # do it thrice to append
     write_schema_table(data, output_file_name, file_format)
     write_schema_table(data, output_file_name, file_format)
     write_schema_table(data, output_file_name, file_format)
 
-    with open(output_file_name, 'r') as csv_file:
-        reader = csv.reader(csv_file, dialect='excel')
+    with open(output_file_name, "r") as csv_file:
+        reader = csv.reader(csv_file, dialect="excel")
         assert next(reader) == list(data[0].keys())
         assert len(csv_file.readlines()) == 3
     os.remove(output_file_name)
 
+
 @mock.patch("phdi_building_blocks.schemas.pq.read_table")
 @mock.patch("phdi_building_blocks.schemas.pq.ParquetFile")
 @mock.patch("phdi_building_blocks.schemas.os.walk")
-def test_print_schema_summary_parquet(patched_os_walk, patched_ParquetFile, patched_reader):
+def test_print_schema_summary_parquet(
+    patched_os_walk, patched_ParquetFile, patched_reader
+):
 
     patched_os_walk.return_value = [("some_path", None, ["filename.parquet"])]
 
@@ -284,6 +286,7 @@ def test_print_schema_summary_parquet(patched_os_walk, patched_ParquetFile, patc
     )
     patched_reader.assert_called_with(pathlib.Path("some_path") / "filename.parquet")
 
+
 @mock.patch("phdi_building_blocks.schemas.os.walk")
 def test_print_schema_summary_csv(patched_os_walk, capsys):
     data = [{"some_column": "some value", "some_other_column": "some other value"}]
@@ -298,11 +301,9 @@ def test_print_schema_summary_csv(patched_os_walk, capsys):
 
     write_schema_table(data, output_file_name, file_format)
 
-    print_schema_summary(schema_directory)            
+    print_schema_summary(schema_directory)
     captured = capsys.readouterr()
     # the \n is because print in python automatically adds \n
-    assert captured.out == "['some_column', 'some_other_column']\n" 
+    assert captured.out == "['some_column', 'some_other_column']\n"
 
     os.remove(output_file_name)
-    
-    

--- a/src/lib/phdi-building-blocks/tests/test_schemas.py
+++ b/src/lib/phdi-building-blocks/tests/test_schemas.py
@@ -229,7 +229,7 @@ def test_write_schema_table_with_writer(patched_pa_table, patched_writer):
 
 def test_write_schema_table_new_csv():
     data = [{"some_column": "some value", "some_other_column": "some other value"}]
-    output_file_name = r'./phdi-building-blocks/tests/output/create_new.csv';
+    output_file_name = 'create_new.csv'
     file_format = "csv"
 
     if os.path.isfile(output_file_name):
@@ -241,9 +241,11 @@ def test_write_schema_table_new_csv():
         reader = csv.reader(csv_file, dialect='excel')
         assert next(reader) == list(data[0].keys())
 
+    os.remove(output_file_name)
+
 def test_write_schema_table_append_csv():
     data = [{"some_column": "some value", "some_other_column": "some other value"}]
-    output_file_name = r'./phdi-building-blocks/tests/output/append.csv';
+    output_file_name = 'append.csv';
     file_format = "csv"
 
     if os.path.isfile(output_file_name):
@@ -258,6 +260,7 @@ def test_write_schema_table_append_csv():
         reader = csv.reader(csv_file, dialect='excel')
         assert next(reader) == list(data[0].keys())
         assert len(csv_file.readlines()) == 3
+    os.remove(output_file_name)
 
 @mock.patch("phdi_building_blocks.schemas.pq.read_table")
 @mock.patch("phdi_building_blocks.schemas.pq.ParquetFile")
@@ -281,24 +284,25 @@ def test_print_schema_summary_parquet(patched_os_walk, patched_ParquetFile, patc
     )
     patched_reader.assert_called_with(pathlib.Path("some_path") / "filename.parquet")
 
-# def test_print_schema_summary_csv(capsys):
-#     data = [{"some_column": "some value", "some_other_column": "some other value"}]
-#     output_file_name = r'./phdi-building-blocks/tests/output/print_schema.csv';
-#     file_format = "csv"
+@mock.patch("phdi_building_blocks.schemas.os.walk")
+def test_print_schema_summary_csv(patched_os_walk, capsys):
+    data = [{"some_column": "some value", "some_other_column": "some other value"}]
+    output_file_name = "print_schema.csv"
+    file_format = "csv"
 
-#     if os.path.isfile(output_file_name):
-#         os.remove(output_file_name)
+    patched_os_walk.return_value = [("", None, ["print_schema.csv"])]
+    schema_directory = mock.Mock()
 
-#     write_schema_table(data, output_file_name, file_format)
+    if os.path.isfile(output_file_name):
+        os.remove(output_file_name)
 
-#     # captured_print = io.StringIO()                  
-#     # sys.stdout = captured_print                     
-#     test = print_schema_summary(output_file_name)
-#     # sys.stdout = sys.__stdout__    
-#     # assert captured_print.getvalue() == "some_column,some_other_column"                 
+    write_schema_table(data, output_file_name, file_format)
 
-#     captured = capsys.readouterr()
-#     assert test == 'hi'
-#     assert captured.out == "some_column,some_other_column" 
+    print_schema_summary(schema_directory)            
+    captured = capsys.readouterr()
+    # the \n is because print in python automatically adds \n
+    assert captured.out == "['some_column', 'some_other_column']\n" 
+
+    os.remove(output_file_name)
     
     

--- a/src/lib/phdi-building-blocks/tests/test_schemas.py
+++ b/src/lib/phdi-building-blocks/tests/test_schemas.py
@@ -1,4 +1,9 @@
+import csv
+import io
 import json
+import os
+import sys
+import pytest
 import yaml
 import pathlib
 from unittest import mock
@@ -222,11 +227,42 @@ def test_write_schema_table_with_writer(patched_pa_table, patched_writer):
     writer.write_table.assert_called_with(table=table)
     assert len(patched_writer.call_args_list) == 0
 
+def test_write_schema_table_new_csv():
+    data = [{"some_column": "some value", "some_other_column": "some other value"}]
+    output_file_name = r'./phdi-building-blocks/tests/output/create_new.csv';
+    file_format = "csv"
+
+    if os.path.isfile(output_file_name):
+        os.remove(output_file_name)
+    
+    write_schema_table(data, output_file_name, file_format)
+
+    with open(output_file_name, 'r') as csv_file:
+        reader = csv.reader(csv_file, dialect='excel')
+        assert next(reader) == list(data[0].keys())
+
+def test_write_schema_table_append_csv():
+    data = [{"some_column": "some value", "some_other_column": "some other value"}]
+    output_file_name = r'./phdi-building-blocks/tests/output/append.csv';
+    file_format = "csv"
+
+    if os.path.isfile(output_file_name):
+        os.remove(output_file_name)
+    
+    # do it thrice to append
+    write_schema_table(data, output_file_name, file_format)
+    write_schema_table(data, output_file_name, file_format)
+    write_schema_table(data, output_file_name, file_format)
+
+    with open(output_file_name, 'r') as csv_file:
+        reader = csv.reader(csv_file, dialect='excel')
+        assert next(reader) == list(data[0].keys())
+        assert len(csv_file.readlines()) == 3
 
 @mock.patch("phdi_building_blocks.schemas.pq.read_table")
 @mock.patch("phdi_building_blocks.schemas.pq.ParquetFile")
 @mock.patch("phdi_building_blocks.schemas.os.walk")
-def test_print_schema_summary(patched_os_walk, patched_ParquetFile, patched_reader):
+def test_print_schema_summary_parquet(patched_os_walk, patched_ParquetFile, patched_reader):
 
     patched_os_walk.return_value = [("some_path", None, ["filename.parquet"])]
 
@@ -244,3 +280,25 @@ def test_print_schema_summary(patched_os_walk, patched_ParquetFile, patched_read
         pathlib.Path("some_path") / "filename.parquet"
     )
     patched_reader.assert_called_with(pathlib.Path("some_path") / "filename.parquet")
+
+# def test_print_schema_summary_csv(capsys):
+#     data = [{"some_column": "some value", "some_other_column": "some other value"}]
+#     output_file_name = r'./phdi-building-blocks/tests/output/print_schema.csv';
+#     file_format = "csv"
+
+#     if os.path.isfile(output_file_name):
+#         os.remove(output_file_name)
+
+#     write_schema_table(data, output_file_name, file_format)
+
+#     # captured_print = io.StringIO()                  
+#     # sys.stdout = captured_print                     
+#     test = print_schema_summary(output_file_name)
+#     # sys.stdout = sys.__stdout__    
+#     # assert captured_print.getvalue() == "some_column,some_other_column"                 
+
+#     captured = capsys.readouterr()
+#     assert test == 'hi'
+#     assert captured.out == "some_column,some_other_column" 
+    
+    


### PR DESCRIPTION
[Link](https://reportstream-service-request.clickup.com/t/2h264r0) to ticket

In addition to parquet, the application will now support CSV when writing schema tables. This allows epis to have an additional file type to do analysis on. Tests are also included in this PR