### PR TITLE
Default to None for Missing Values in FHIR to Data Mart ETL Pipeline

### DIFF
--- a/src/lib/phdi-building-blocks/phdi_building_blocks/schemas.py
+++ b/src/lib/phdi-building-blocks/phdi_building_blocks/schemas.py
@@ -82,7 +82,7 @@ def apply_schema_to_resource(resource: dict, schema: dict) -> dict:
         value = fhirpathpy.evaluate(resource, path)
 
         if len(value) == 0:
-            data[resource_schema[field]["new_name"]] = ""
+            data[resource_schema[field]["new_name"]] = None
         else:
             selection_criteria = resource_schema[field]["selection_criteria"]
             value = apply_selection_criteria(value, selection_criteria)


### PR DESCRIPTION
# Description
This PR addresses an issue where non-string fields (e.g. latitude or longitude) that were missing for a resource were being defaulted to `""` instead of `None`. The issue was cashing the entire pipeline to crash when trying to write the data to a Parquet file because Parquet was trying to convert the string to a double. By setting the default value for missing fields to `None`, Parquet is able to properly handle the missing data.

# Test Plan
This has been tested in a Jupyter notebook using Patient data that included latitude and longitude. I first ran the data through the code as written, observed that it failed, and then modified the `apply_schema_to_resource` function locally to use `None` instead of `""`. I ran the data through the updated version of the code and observed that it worked.