### PR TITLE
Demo analytics notebook

### DIFF
--- a/examples/parquet_analytics_demo.ipynb
+++ b/examples/parquet_analytics_demo.ipynb
@@ -1,0 +1,470 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "af5806d3",
+   "metadata": {},
+   "source": [
+    "# Parquet Analytics Demo Notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f5d5a85",
+   "metadata": {},
+   "source": [
+    "This notebook serves as a brief demonstration of how a set of cloud-hosted parquet files can be analyzed locally using R. While the analysis in this notebook consists of contrived / toy examples, the data being operated on is in fact _real_! It is currently stored in the FHIR server as part of the PHDI Ingestion Pipeline and has been transformed and standardized by a number of preceding building blocks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc8062d0",
+   "metadata": {},
+   "source": [
+    "To run this notebook, you'll need to configure your system to recognize the R kernel. A simple tutorial can be found here: https://irkernel.github.io/installation/. To start, make sure you've installed the latest version of R, available from the CRAN repository at https://cloud.r-project.org/index.html. Then, launch R from the terminal with the `R` command. **Important:** Do not launch R from the app--the following package installation **must** be performed from the terminal (this is because the R app does not consistently respect PATH changes set in bash profiles). Run `install.packages(IRkernel)`, then run `IRkernel::installspec()`. That's it! Your notebook software can now \"see\" the R kernel on your machine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eca904da",
+   "metadata": {},
+   "source": [
+    "## Packages and imports"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93cdcd4d",
+   "metadata": {},
+   "source": [
+    "We'll begin by installing the relevant analytics packages that we'll use for our examples. We'll need:\n",
+    "* `arrow`\n",
+    "* `ggplot2`\n",
+    "* `jsonlite`\n",
+    "* `geojsonio`\n",
+    "* `sf`\n",
+    "* `tidyverse`\n",
+    "\n",
+    "which you can install individually by running `install.packages(arrow)`, etc. These packages allow us to load parquet data, interact with and format data the way we want, and visualize our result. Additionally, we'll need two packages specific to accessing Microsoft's Azure platform: `AzureStor` and `AzureRMR`.\n",
+    "\n",
+    "While common practice is to use the `rgdal` package for spatial analytics purposes (see last example), `rgdal` will reach its end-of-supported lifecycle in early 2023. Hence, we recommend the new industry standard `sf` package (standing for \"simple features\")."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2e39b1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import relevant packages\n",
+    "library(arrow)\n",
+    "library(jsonlite)\n",
+    "library(AzureStor)\n",
+    "library(AzureRMR)\n",
+    "library(sf)\n",
+    "library(geojsonio)\n",
+    "library(tidyverse)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acaf7238",
+   "metadata": {},
+   "source": [
+    "## Access and download data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0871e7a",
+   "metadata": {},
+   "source": [
+    "Now that we've got our package environment set up, let's load the data. This notebook demonstrates the important fact that the output of the PHDI Building Blocks pipeline are cloud-hosted files that are accessible locally for all manner of analytics. Let's access the Storage Account and pull down the parquet data to read into R."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d76d4d85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configure container access to Azure storage\n",
+    "az <- create_azure_login(tenant=\"9ce70869-60db-44fd-abe8-d2767077fc8f\", host=\"https://storage.azure.com/\")\n",
+    "token <- az$token$credentials$access_token\n",
+    "adls_ep <- adls_endpoint(\"https://pitestdatasa.dfs.core.windows.net/\", token=token)\n",
+    "container <- storage_container(adls_ep, \"gold\")\n",
+    "\n",
+    "# Initialize some tempfiles to buffer data into\n",
+    "phdi_conditions = tempfile()\n",
+    "phdi_organizations = tempfile()\n",
+    "phdi_compositions = tempfile()\n",
+    "phdi_patients = tempfile()\n",
+    "\n",
+    "# Perform storage download, copying data into the temp files\n",
+    "storage_download(container, \"Condition.parquet\", phdi_conditions)\n",
+    "storage_download(container, \"organization.parquet\", phdi_organizations)\n",
+    "storage_download(container, \"composition.parquet\", phdi_compositions)\n",
+    "storage_download(container, \"patient.parquet\", phdi_patients)\n",
+    "\n",
+    "# Notice that we can read-in only a subset of columns if we so choose\n",
+    "# i.e. It's not necessary to fully read the file to memory\n",
+    "conditions = read_parquet(phdi_conditions, col_select = c(\"patient_id\", \"onset_date\"))\n",
+    "organizations = read_parquet(phdi_organizations)\n",
+    "compositions = read_parquet(phdi_compositions)\n",
+    "patients = read_parquet(phdi_patients)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a83320d1",
+   "metadata": {},
+   "source": [
+    "We've now created local copies of all data that maps into the ECR schema--we have resources for Patients, Conditions, Organizations, and Compositions (between patients and organizations). Importantly, we've stored all of this data into `tempfiles` which will persist _only_ as long as our current R session. That way, when we're finished with analysis, the files will be cleared, leaving no chance for PII to linger. We'll use these file for the remainder of our analysis demo, noting that pulling files down this way allows analysts to experiment freely on data without any risk of corrupting the source of truth.\n",
+    "\n",
+    "Before getting into some demo analytics problems, we need to do a bit of data modification and format. If we try to visualize the `patient` data frame, we'll get the following error:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d4e9a0c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(patients)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0749f6fb",
+   "metadata": {},
+   "source": [
+    "This is because the `phone_number` column is nost only a nested list, but because the information stored within that column is of variable length (because some patients have phone numbers on file while others do not). Let's format this column to line up with what we'd like our data frame to be: a singular, flattened entity on which we can do joins and perform analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e56dbcf0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Flatten the list column to a series of regular columns\n",
+    "patients <- patients %>% unnest(phone_number)\n",
+    "patients <- subset(patients, select = -c(system, use))\n",
+    "patients <- rename(patients, phone_number = value)\n",
+    "\n",
+    "# Only display the columns of the data frame that don't contain PII\n",
+    "head(patients[,c(\"patient_id\", \"gender\", \"state\", \"country\")])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d562a625",
+   "metadata": {},
+   "source": [
+    "### Joining Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e9fde8a",
+   "metadata": {},
+   "source": [
+    "The first thing we'll likely want to do with our data is join it. We have separate tables for each of the various resources we pulled down in our schema, but if we want to answer questions _across_ the data, we'll need to connect the dots. The `patient_id` field uniquely generated for all patients in the database is a great way of doing just this. Let's run joins to attach our other resources to the patients they're associated with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d713f98a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Perform join--patients and conditions share a patient_id field,\n",
+    "# and we can use the composition to associate patients with the\n",
+    "# organizations they're associated to\n",
+    "joined_df <- patients %>%\n",
+    "    left_join(conditions, by = \"patient_id\") %>%\n",
+    "    left_join(compositions, by = \"patient_id\") %>%\n",
+    "    left_join(organizations, by = \"organization_id\")\n",
+    "colnames(joined_df)\n",
+    "head(joined_df[,c(\"patient_id\", \"onset_date\", \"organization_id\")])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd9379ec",
+   "metadata": {},
+   "source": [
+    "We can see that there are a few duplicate entries just in the head of this joint data frame. This is because one patient could have multiple pre-existing conditions, each of which could be associated with care at a different organization. In other words, duplicates are perfectly okay for now, but we'll have to keep this in mind when we get to some of our analytics examples below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f89989c7",
+   "metadata": {},
+   "source": [
+    "### Answering Exploratory Profiling Questions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c087bad",
+   "metadata": {},
+   "source": [
+    "Now that we've created joint data sets, we want to start exploring the data to answer questions. Some of the most basic exploration questions we're likely to encounter involve profiling data along demographic fields. For example: what are the relative ratios of each gender in this data set? We can easily answer this question by performing some counting analysis on our data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e24457cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an aggregate count of a one-variable field in the data\n",
+    "# Use mutate to turn this into a percentage for clear visualization\n",
+    "counts <- patients %>% \n",
+    "    group_by(gender) %>%\n",
+    "    count() %>% \n",
+    "    ungroup() %>% \n",
+    "    mutate(perc = `n` / sum(`n`)) %>% \n",
+    "    arrange(perc) %>%\n",
+    "    mutate(labels = scales::percent(perc))\n",
+    "\n",
+    "# A pie chart is a helpful way of visualizing this information\n",
+    "ggplot(counts, aes(x = \"\", y = perc, fill = gender)) +\n",
+    "    geom_col() +\n",
+    "    geom_text(aes(label = labels), position = position_stack(vjust = 0.5)) +\n",
+    "    coord_polar(theta = \"y\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef18a593",
+   "metadata": {},
+   "source": [
+    "### Time Series Analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3245b57c",
+   "metadata": {},
+   "source": [
+    "Now that we've answered a simple question, let's look a little deeper. Suppose we're interested in the onset of various medical problems over time. We want to see if there are any identifiable trends in the number of conditions that patients in the data have reported. Our pulled down data allows us to easily answer this question as well. We'll start by creating a more generalized variable for the year of a condition's onset, instead of the precise date, in order to facilitate counting statistics. Then, it's just a matter of grouping and plotting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e6b393c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract the year of a condition's onset into its own variable to enable counting\n",
+    "# Also eliminate rows where a condition is missing time information\n",
+    "conditions <- conditions[!(is.na(conditions$onset_date) | conditions$onset_date == \"\"),]\n",
+    "conditions$onset_year <- conditions$onset_date %>%\n",
+    "    map(str_split, pattern = \"-\") %>%\n",
+    "    map(pluck(1)) %>%\n",
+    "    map(pluck(1)) %>%\n",
+    "    unlist()    # Need to invoke this because map always returns a list\n",
+    "\n",
+    "# Tabulate stats on number of occurences\n",
+    "counts <- conditions %>%\n",
+    "    group_by(onset_year) %>%\n",
+    "    count() %>%\n",
+    "    ungroup() %>%\n",
+    "    arrange(onset_year)\n",
+    "\n",
+    "# And plot\n",
+    "ggplot(counts, aes(x = onset_year, y = n, group = 1)) +\n",
+    "    geom_point() +\n",
+    "    geom_line() +\n",
+    "    labs(x = \"Reporting Year\", y = \"# of Patients With Condition Onset in Year\", title = \"Condition Onset Over Time\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27ef9596",
+   "metadata": {},
+   "source": [
+    "### A Fake Status Histogram"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4638e141",
+   "metadata": {},
+   "source": [
+    "Next, let's make a toy assumption for the purpose of demonstration. Let's create a \"fake\" status for each patient in our data by treating the last digit of their phone number as if it was indicative of some sort of status or test (this is obviously completely random, but it helps bear out the graph). We'll begin by extracting this last digit into its own \"status\" field, and then we'll visualize a histogram of the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "668c979f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract last digit of phone number into its own field and convert to numeric\n",
+    "patients_with_phones <- patients[!(is.na(patients$phone_number) | patients$phone_number == \"\"),]\n",
+    "patients_w_status <- patients_with_phones %>%\n",
+    "  mutate(\n",
+    "    status=as.numeric(stringr::str_sub(phone_number,-1,-1))\n",
+    "  )\n",
+    "\n",
+    "# Now let's visualize what that looks like\n",
+    "ggplot(patients_w_status) +\n",
+    "    geom_histogram(aes(x=status),fill=\"green\",color=\"white\",bins=10) +\n",
+    "    ggtitle(\"Patient Status Test\") + theme_minimal()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be022140",
+   "metadata": {},
+   "source": [
+    "### A Choropleth Visualization Of Patients"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4046bf3a",
+   "metadata": {},
+   "source": [
+    "For our final example, let's do something a little more applicable. Using the joined data we created in the first example above, let's create a choropleth visualization of this data disaggregated across the state of Virginia (a _choropleth_ chart is a map where each region is color-coded by intensity of some numerical variable, like a heatmap). We'll be using the most 2018 tracts information on counties and subcounties published by Virginia itself, available [here](https://catalog.data.gov/dataset/tiger-line-shapefile-2018-state-virginia-current-census-tract-state-based). While it's possible to use data formats such as GeoJSON for spatial analysis, we'll opt for a shapefile, as that's the preferred layer format used by most US Federal agencies and surveys (such as the Census). We'll be performing only a basic analysis, creating a choropleth for all patients in our dataset with preexisting conditions, but the points made below are applicable to a wide variety of geospatial applications.\n",
+    "\n",
+    "Let's start by reading in our geospatial data for the state of Virginia and visualizing what the map looks like when blank."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b76e6e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the shapefile using the sf package\n",
+    "va_tracts = st_read(\"/Users/Brandon/Downloads/tl_2018_51_tract/tl_2018_51_tract.shp\")\n",
+    "# Geodetic CRS is the Coordinate Reference System that encodes the multipolygons\n",
+    "# NAD83 Corresponds to code US 4269, which is the CRS most commonly used by \n",
+    "# Federal Agencies (https://www.nceas.ucsb.edu/sites/default/files/2020-04/OverviewCoordinateReferenceSystems.pdf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecc3e5ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(va_tracts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51e4a56c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ggplot() + \n",
+    "  geom_sf(data = va_tracts) + \n",
+    "  ggtitle(\"Spatial Decomposition of Virginia\") + \n",
+    "  coord_sf()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6647baf",
+   "metadata": {},
+   "source": [
+    "We can sense a good projection of the various counties and tracts in the state. There are even some pockets so dense with drawing that it looks colored-in (but this is just an artifact of the drawing process in such close proximity). \n",
+    "\n",
+    "Let's identify the patients in our joint dataset that have preexisting conditions. We can do this using some simple filtering techniques, assuming that if the `onset_date` column from the `Conditions` table is blank, then there is no condition associated with that patient. Also, recall that we observed duplicates in our data frame after joining, representing the possibility of patients with multiple conditions. To account for this, we'll only consider distinct patients and their conditions by geography."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30a4db96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "patients_with_conditions <- joined_df[!(joined_df$onset_date == \"\" | is.na(joined_df$onset_date)),]\n",
+    "de_duped <- patients_with_conditions %>% distinct(patient_id, onset_date, latitude, longitude)\n",
+    "\n",
+    "# Also drop patients lacking geographical information\n",
+    "de_duped <- de_duped[!(is.na(de_duped$longitude) | is.na(de_duped$latitude)),]\n",
+    "\n",
+    "nrow(joined_df)\n",
+    "nrow(de_duped)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93c58c47",
+   "metadata": {},
+   "source": [
+    "Taking distinct values along these dimensions cut the size of our joint data set by an order of magnitude! Now that we have our distinct patients and their conditions, we can use the `sf` package to place them geographically within VA's tract plots using `point-in-polygon` functionality. This will allow us to join our two dataframes on a common identifier, which will let us visualize the map filled-in with color."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18a1c611",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert base patient data into a spatial-features data for point placement\n",
+    "geolocated_patients <- de_duped %>%\n",
+    "    mutate_at(vars(longitude, latitude), as.numeric) %>%   # coordinates must be numeric\n",
+    "        st_as_sf(\n",
+    "        coords = c(\"longitude\", \"latitude\"),\n",
+    "        agr = \"constant\",\n",
+    "        crs = 4269,        # nad83\n",
+    "        stringsAsFactors = FALSE,\n",
+    "        remove = TRUE\n",
+    "    )\n",
+    "\n",
+    "# Use spatial join to place patients into the correct tracts\n",
+    "patient_in_tract <- st_join(geolocated_patients, va_tracts, join=st_within)\n",
+    "tract_count <- count(as_tibble(patient_in_tract), NAME)\n",
+    "choro_df <- left_join(fortify(va_tracts), tract_count, by = \"NAME\") %>% rename(patients_with_conditions = n)\n",
+    "\n",
+    "# And let's see what it looks like!\n",
+    "ggplot(choro_df, aes(fill = patients_with_conditions)) + \n",
+    "    geom_sf() + \n",
+    "    scale_fill_distiller(\n",
+    "        type = \"seq\",\n",
+    "        palette = \"Blues\",\n",
+    "        na.value = \"transparent\",\n",
+    "        direction = 1\n",
+    "    ) +\n",
+    "    theme_void() +\n",
+    "    ggtitle(\"Spatial Decomposition of Virginia\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "R",
+   "language": "R",
+   "name": "ir"
+  },
+  "language_info": {
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This change set introduces a demo notebook for use with the ECR data mart to show some toy examples of how our work can:

a. pull data from cloud-hosted storage
b. read parquet files into R for analysis and manipulation
c. work through some trivial analysis and visualization problems
d. show a somewhat meaningful choropleth graph akin to the one Vincent developed months ago.

The notebook can be run through jupyter if the R Kernel is configured to do so (the notebook includes instructions on setting this up).

Tagging Bryan and Dan as the reviewers since this is client/product facing and Dan has experience with notebooks and as someone on the receiving side of work like this.