### PR TITLE
Schemas.py datatype fix and performance improvements

### DIFF
--- a/src/lib/phdi-building-blocks/phdi_building_blocks/schemas.py
+++ b/src/lib/phdi-building-blocks/phdi_building_blocks/schemas.py
@@ -8,10 +8,11 @@ import pyarrow.parquet as pq
 import random
 import yaml
 
+from functools import cache
 from pathlib import Path
 from phdi_building_blocks.azure import AzureFhirServerCredentialManager
 from phdi_building_blocks.fhir import fhir_server_get
-from typing import Literal, List, Union
+from typing import Literal, List, Union, Callable
 
 
 def load_schema(path: str) -> dict:
@@ -63,6 +64,20 @@ def apply_selection_criteria(
     return value
 
 
+@cache
+def __get_fhirpathpy_parser(fhirpath_expression: str) -> Callable:
+    """
+    Return a fhirpathpy parser for a specific FHIRPath.  This cached function minimizes
+    calls to the relatively expensive :func:`fhirpathpy.compile` function for any given
+    `fhirpath_expression`
+
+    :param fhirpath_expression: The FHIRPath expression to evaluate
+    :return: A callable function that accepts a FHIR resource `dict` and
+        evaluates `fhirpath_expression` on it
+    """
+    return fhirpathpy.compile(fhirpath_expression)
+
+
 def apply_schema_to_resource(resource: dict, schema: dict) -> dict:
     """
     Given a resource and a schema, return a dictionary with values of the data
@@ -79,14 +94,16 @@ def apply_schema_to_resource(resource: dict, schema: dict) -> dict:
         return data
     for field in resource_schema.keys():
         path = resource_schema[field]["fhir_path"]
-        value = fhirpathpy.evaluate(resource, path)
+
+        parse_function = __get_fhirpathpy_parser(path)
+        value = parse_function(resource)
 
         if len(value) == 0:
-            data[resource_schema[field]["new_name"]] = None
+            data[resource_schema[field]["new_name"]] = ""
         else:
             selection_criteria = resource_schema[field]["selection_criteria"]
             value = apply_selection_criteria(value, selection_criteria)
-            data[resource_schema[field]["new_name"]] = value
+            data[resource_schema[field]["new_name"]] = str(value)
 
     return data
 
@@ -113,7 +130,8 @@ def make_table(
 
         output_file_name = output_path / f"{resource_type}.{output_format}"
 
-        query = f"/{resource_type}"
+        # TODO: make _count (and other query parameters) configurable
+        query = f"/{resource_type}?_count=1000"
         url = fhir_url + query
 
         writer = None

--- a/src/lib/phdi-building-blocks/poetry.lock
+++ b/src/lib/phdi-building-blocks/poetry.lock
@@ -851,8 +851,8 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.9"
-content-hash = "8190eacb8f51df27fc97529e21c1a25246cd9f840f3000be45dfd58ef6e45dcd"
+python-versions = "^3.8"
+content-hash = "66c873f51f77638fb1620547bbfed9f5b63c19928cd1d155478bcd65aa9e3ed9"
 
 [metadata.files]
 alabaster = [

--- a/src/lib/phdi-building-blocks/pyproject.toml
+++ b/src/lib/phdi-building-blocks/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = []
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.8"
 smartystreets-python-sdk = "^4.10.6"
 pydantic = "^1.9.0"
 hl7 = "^0.4.5"

--- a/src/lib/phdi-building-blocks/pyproject.toml
+++ b/src/lib/phdi-building-blocks/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = []
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 smartystreets-python-sdk = "^4.10.6"
 pydantic = "^1.9.0"
 hl7 = "^0.4.5"


### PR DESCRIPTION
# Description
This PR introduces a few fixes and performance improvements described below.

## Force string datatype
Previously, iterative calls to write parquet files could fail when a single field for multiple consecutive records contained null values.  In this case, the schema derived by Pyarrow could be `string`, `double`, or some other datatype when values are present and `null` if all values in a write batch were empty.  

Updated to cast all values as strings, and store empty values as empty strings. This way, Pyarrow always derives a "string" data type.  Code will be updated in the future to support other data types, potentially by adding support for declaring data types in the schema definition.

## Hardcoded _count parameter for FHIR searches
Hardcode _count=1000 (increased from the default of 10 on Azure FHIR Server) to improve performance by increasing page size for searches, thus reducing the number of FHIR server calls.

## Cached fhirpathpy.compile calls
Previously, we called fhirpathpy.evaluate for every field in every resource, which numbers in the millions.  `fhirpathpy.evaluate` in turn called `fhirpathpy.compile` which takes about .045 seconds per call on average based on testing.

schemas.py has been updated to cache the result of fhirpathpy.compile for each FHIRPath in the schema, thus eliminating many, many calls to `fhirpathpy.compile`.  Testing shows ~10x runtime improvement with caching implemented.
