### PR TITLE
Enhanced logging for FhirServer Upload

### DIFF
--- a/src/FunctionApps/python/IntakePipeline/__init__.py
+++ b/src/FunctionApps/python/IntakePipeline/__init__.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 import azure.functions as func
 from azure.core.exceptions import ResourceExistsError
+from requests import Response
 
 from config import get_required_config
 
@@ -62,7 +63,7 @@ def run_pipeline(
     invalid_output_path = get_required_config("INVALID_OUTPUT_CONTAINER_PATH")
 
     # Attempt conversion to FHIR
-    response = convert_message_to_fhir(
+    convert_response = convert_message_to_fhir(
         message=message,
         filename=message_mappings["filename"],
         input_data_type=message_mappings["input_data_type"],
@@ -77,8 +78,8 @@ def run_pipeline(
 
     # We got a valid conversion so apply desired standardizations
     # sequentially and then add the linking identifier
-    if response and response.get("resourceType") == "Bundle":
-        bundle = response
+    if convert_response and convert_response.status_code == 200:
+        bundle = convert_response.json()
         standardized_bundle = standardize_patient_names(bundle)
         standardized_bundle = standardize_all_phones(standardized_bundle)
         standardized_bundle = geocode_patients(standardized_bundle, geocoder)
@@ -100,44 +101,93 @@ def run_pipeline(
             )
 
         # Don't forget to import the bundle to the FHIR server as well
-        upload_bundle_to_fhir_server(standardized_bundle, cred_manager, fhir_url)
+        upload_response = upload_bundle_to_fhir_server(
+            standardized_bundle, cred_manager, fhir_url
+        )
+
+        if upload_response.status_code != 200:
+            # Record when the entire upload batch request fails
+            __record_error_response(
+                container_url=container_url,
+                output_path=invalid_output_path,
+                message_mappings=message_mappings,
+                transaction_type="upload",
+                message=message,
+                response=upload_response,
+            )
+        else:
+            # When individual transaction(s) fail in an upload batch,
+            # record error detail in the response
+            upload_response_json = upload_response.json()
+            upload_response_entries = upload_response_json.get("entry", [])
+
+            for entry_index, entry in enumerate(upload_response_entries):
+                # FHIR bundle.entry.response.status is string type - integer status code
+                # plus may inlude a message
+                if not entry.get("response", {}).get("status", "").startswith("200"):
+                    store_data(
+                        container_url=container_url,
+                        prefix=invalid_output_path,
+                        filename=f"{message_mappings['filename']}.entry-{entry_index}"
+                        + f".{message_mappings['file_suffix']}",
+                        bundle_type=message_mappings["bundle_type"],
+                        message_json={"entry_index": entry_index, "entry": entry},
+                    )
 
     # For some reason, the HL7/CCDA message failed to convert.
     # This might be failure to communicate with the FHIR server due to
     # access/authentication reasons, or potentially malformed timestamps
     # in the data
     else:
-        try:
-            # First attempt is storing the message directly in the
-            # invalid messages container
-            store_data(
-                container_url,
-                invalid_output_path,
-                f"{message_mappings['filename']}.{message_mappings['file_suffix']}",
-                message_mappings["bundle_type"],
-                message=message,
-            )
-        except ResourceExistsError:
-            logging.warning(
-                "Attempted to store preexisting resource: "
-                + f"{message_mappings['filename']}.{message_mappings['file_suffix']}"
-            )
-        try:
-            # Then, try to store the conversion response information
-            store_data(
-                container_url,
-                invalid_output_path,
-                f"{message_mappings['filename']}.{message_mappings['file_suffix']}"
-                + ".convert-resp",
-                message_mappings["bundle_type"],
-                message_json=response,
-            )
-        except ResourceExistsError:
-            logging.warning(
-                "Attempted to store preexisting resource: "
-                + f"{message_mappings['filename']}.{message_mappings['file_suffix']}"
-                + ".convert-resp"
-            )
+        __record_error_response(
+            container_url=container_url,
+            output_path=invalid_output_path,
+            message_mappings=message_mappings,
+            transaction_type="convert",
+            message=message,
+            response=convert_response,
+        )
+
+
+def __record_error_response(
+    container_url: str,
+    output_path: str,
+    message_mappings: dict,
+    transaction_type: str,
+    message: str,
+    response: Response,
+):
+    try:
+        # First attempt is storing the message directly in the
+        # invalid messages container
+        store_data(
+            container_url,
+            output_path,
+            f"{message_mappings['filename']}.{message_mappings['file_suffix']}",
+            message_mappings["bundle_type"],
+            message=message,
+        )
+    except ResourceExistsError:
+        logging.warning(
+            "Attempted to store preexisting resource: "
+            + f"{message_mappings['filename']}.{message_mappings['file_suffix']}"
+        )
+    try:
+        # Then, try to store the response information
+        store_data(
+            container_url,
+            output_path,
+            f"{message_mappings['filename']}.{message_mappings['file_suffix']}"
+            + f".{transaction_type}-resp",
+            message_mappings["bundle_type"],
+            message_json=response.json(),
+        )
+    except ResourceExistsError:
+        logging.warning(
+            "Attempted to store preexisting resource: "
+            + f"{message_mappings['filename']}.{message_mappings['file_suffix']}"
+            + f".{transaction_type}-resp"
+        )
 
 
 def main(blob: func.InputStream) -> None:

--- a/src/lib/phdi-building-blocks/phdi_building_blocks/azure.py
+++ b/src/lib/phdi-building-blocks/phdi_building_blocks/azure.py
@@ -6,6 +6,7 @@ from azure.identity import DefaultAzureCredential
 from azure.storage.blob import ContainerClient
 from datetime import datetime, timezone
 from phdi_building_blocks.utils import http_request_with_retry
+from requests import Response
 
 
 class AzureFhirServerCredentialManager:
@@ -60,7 +61,7 @@ class AzureFhirServerCredentialManager:
 def _http_request_with_reauth(
     cred_manager: AzureFhirServerCredentialManager,
     **kwargs: dict,
-):
+) -> Response:
     """
     First, call :func:`utils.http_request_with_retry`.  If the first call failed
     with an authorization error (HTTP status 401), obtain a new token using the

--- a/src/lib/phdi-building-blocks/phdi_building_blocks/azure.py
+++ b/src/lib/phdi-building-blocks/phdi_building_blocks/azure.py
@@ -1,7 +1,9 @@
 import json
+import logging
 import pathlib
 
 from azure.core.credentials import AccessToken
+from azure.core.exceptions import ResourceExistsError
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import ContainerClient
 from datetime import datetime, timezone
@@ -119,11 +121,9 @@ def store_data(
     :param prefix: The "filepath" prefix used to navigate the
       virtual directories to the output container
     :param filename: The name of the file to write the data to
-    :param bundle_type: The type of data (FHIR or HL7) being written
-    :param message_json: The content of a message encoded in json
-      format. Used when the input data type is FHIR.
-    :param message: The content of a message encoded as a raw bytestring.
-      Used when the input data type is HL7.
+    :param bundle_type: The type of data being written (VXU, ELR, etc)
+    :param message_json: The content of a message encoded in json format.
+    :param message: The content of a message encoded as a string.
     """
     client = get_blob_client(container_url)
     blob = client.get_blob_client(str(pathlib.Path(prefix) / bundle_type / filename))
@@ -131,3 +131,55 @@ def store_data(
         blob.upload_blob(json.dumps(message_json).encode("utf-8"), overwrite=True)
     elif message is not None:
         blob.upload_blob(bytes(message, "utf-8"), overwrite=True)
+
+
+def store_message_and_response(
+    container_url: str,
+    prefix: str,
+    bundle_type: str,
+    message_filename: str,
+    response_filename: str,
+    message: str,
+    response: Response,
+):
+    """
+    Store information about an incoming message as well as an http response for a
+    transaction related to that message.  This method can be used to
+    record a failed response to a transaction related to an inbound transaction for
+    troubleshooting purposes.
+
+        :param container_url: The url at which to access the container
+        :param prefix: The "filepath" prefix used to navigate the
+        virtual directories to the output container
+        :param bundle_type: The type of data being written
+        :param message_filename: The file name to use to store the message
+        in blob storage
+        :param response_filename: The file name to use to store the response content
+        in blob storage
+        :param message: The content of a message encoded as a string.
+        :param response: HTTP response information from a transaction related to the
+        `message`.
+    """
+    try:
+        # First attempt is storing the message directly in the
+        # invalid messages container
+        store_data(
+            container_url=container_url,
+            prefix=prefix,
+            filename=message_filename,
+            bundle_type=bundle_type,
+            message=message,
+        )
+    except ResourceExistsError:
+        logging.warning(f"Attempted to store preexisting resource: {message_filename}")
+    try:
+        # Then, try to store the response information
+        store_data(
+            container_url=container_url,
+            prefix=prefix,
+            filename=response_filename,
+            bundle_type=bundle_type,
+            message=response.text,
+        )
+    except ResourceExistsError:
+        logging.warning(f"Attempted to store preexisting resource: {response_filename}")

--- a/src/lib/phdi-building-blocks/phdi_building_blocks/conversion.py
+++ b/src/lib/phdi-building-blocks/phdi_building_blocks/conversion.py
@@ -9,6 +9,8 @@ from phdi_building_blocks.azure import (
 
 from typing import List, Dict
 
+from requests import Response
+
 
 def clean_message(message: str) -> str:
     """
@@ -283,17 +285,18 @@ def convert_message_to_fhir(
     template_collection: str,
     cred_manager: AzureFhirServerCredentialManager,
     fhir_url: str,
-) -> dict:
+) -> Response:
     """
     Given a message in either HL7 v2 (pipe-delimited flat file) or CCDA
     (XML), attempt to convert that message into FHIR format (JSON) for
-    further processing using the FHIR server. The FHIR server will respond
-    with a status code of 400 if the message itself is invalid, such as
-    containing improperly formatted timestamps, and if that occurs then an
-    empty dictionary is returned so the pipeline knows to store the
-    original message in a separate container. Otherwise, the FHIR data is
-    returned. HL7v2 messages are cleaned (minor corrections made) via the
-    clean_message function prior to conversion.
+    further processing using the FHIR server. HL7v2 messages are cleaned
+    (minor corrections made) via the clean_message function prior to conversion.
+
+    The FHIR server will respond with a status code of 400 if the message itself
+    is invalid, such as containing improperly formatted timestamps.  Otherwise, the
+    FHIR server will respond with the converted FHIR data. In either case, a
+    `requests.Response` object will be returned.
+
 
     :param message: The raw message that needs to be converted to FHIR.
         Must be HL7v2 or CCDA
@@ -334,6 +337,7 @@ def convert_message_to_fhir(
         headers=headers,
         data=data,
     )
+    print(response)
 
     if response.status_code != 200:
         logging.error(
@@ -341,11 +345,4 @@ def convert_message_to_fhir(
             + f" $convert-data for {filename}"
         )
 
-        error_info = {
-            "http_status_code": response.status_code,
-            "response_content": response.text,
-        }
-
-        return error_info
-
-    return response.json()
+    return response

--- a/src/lib/phdi-building-blocks/phdi_building_blocks/conversion.py
+++ b/src/lib/phdi-building-blocks/phdi_building_blocks/conversion.py
@@ -337,7 +337,6 @@ def convert_message_to_fhir(
         headers=headers,
         data=data,
     )
-    print(response)
 
     if response.status_code != 200:
         logging.error(

--- a/src/lib/phdi-building-blocks/phdi_building_blocks/fhir.py
+++ b/src/lib/phdi-building-blocks/phdi_building_blocks/fhir.py
@@ -358,7 +358,9 @@ def log_fhir_server_error(status_code: int, batch_entry_index: int = None) -> No
 
     batch_decorator = ""
     if batch_entry_index is not None:
-        batch_decorator = f"in entry number {batch_entry_index} of batch "
+        batch_decorator = (
+            f"in zero-based message index {batch_entry_index} of FHIR batch "
+        )
 
     if status_code == 401:
         logging.error(

--- a/src/lib/phdi-building-blocks/phdi_building_blocks/fhir.py
+++ b/src/lib/phdi-building-blocks/phdi_building_blocks/fhir.py
@@ -30,7 +30,7 @@ def generate_filename(blob_name: str, message_index: int) -> str:
 
 def upload_bundle_to_fhir_server(
     bundle: dict, cred_manager: AzureFhirServerCredentialManager, fhir_url: str
-) -> None:
+) -> requests.Response:
     """
     Import a FHIR resource to the FHIR server.
     The submissions may be Bundles or individual FHIR resources.
@@ -42,7 +42,7 @@ def upload_bundle_to_fhir_server(
 
     access_token = cred_manager.get_access_token().token
 
-    _http_request_with_reauth(
+    response = _http_request_with_reauth(
         cred_manager=cred_manager,
         url=fhir_url,
         retry_count=3,
@@ -55,6 +55,29 @@ def upload_bundle_to_fhir_server(
         },
         data=bundle,
     )
+
+    # FHIR uploads are sent as a batch.  Although the batch succeeds,
+    # individual entries within the batch may fail, so we log them here
+    if response.status_code == 200:
+        response_json = response.json()
+        entries = response_json.get("entry", [])
+        for entry_index, entry in enumerate(entries):
+            entry_response = entry.get("response", {})
+
+            # FHIR bundle.entry.response.status is string type - integer status code
+            # plus may inlude a message
+            if entry_response and not entry_response.get("status", "").startswith(
+                "200"
+            ):
+                log_fhir_server_error(
+                    status_code=int(entry_response["status"][0:3]),
+                    batch_entry_index=entry_index,
+                )
+
+    else:
+        log_fhir_server_error(response.status_code)
+
+    return response
 
 
 def export_from_fhir_server(
@@ -327,29 +350,42 @@ def fhir_server_get(
     return response
 
 
-def log_fhir_server_error(status_code: int) -> None:
+def log_fhir_server_error(status_code: int, batch_entry_index: int = None) -> None:
     """Given an HTTP status code from a FHIR server's response, log the specified error.
 
     :param status_code: Status code returned by a FHIR server
     """
+
+    batch_decorator = ""
+    if batch_entry_index is not None:
+        batch_decorator = f"in entry number {batch_entry_index} of batch "
+
     if status_code == 401:
-        logging.error("FHIR SERVER ERROR - Status Code 401: Failed to authenticate.")
+        logging.error(
+            f"FHIR SERVER ERROR {batch_decorator}- Status Code 401: Failed to "
+            + "authenticate."
+        )
 
     elif status_code == 403:
         logging.error(
-            "FHIR SERVER ERROR - Status Code 403: User does not have permission to make that request."  # noqa
+            f"FHIR SERVER ERROR {batch_decorator}- Status Code 403: User does not "
+            + "have permission to make that request."
         )
 
     elif status_code == 404:
         logging.error(
-            "FHIR SERVER ERROR - Status Code 404: Server or requested data not found."
+            f"FHIR SERVER ERROR {batch_decorator}- Status Code 404: Server or "
+            + "requested data not found."
         )
 
     elif status_code == 410:
         logging.error(
-            "FHIR SERVER ERROR - Status Code 410: Server has deleted this cached data."
+            f"FHIR SERVER ERROR {batch_decorator}- Status Code 410: Server has "
+            + "deleted this cached data."
         )
 
     elif str(status_code).startswith(("4", "5")):
-        error_message = f"FHIR SERVER ERROR - Status code {status_code}"
+        error_message = (
+            f"FHIR SERVER ERROR {batch_decorator}- Status code {status_code}"
+        )
         logging.error(error_message)

--- a/src/lib/phdi-building-blocks/tests/test_conversion.py
+++ b/src/lib/phdi-building-blocks/tests/test_conversion.py
@@ -179,7 +179,8 @@ def test_convert_message_to_fhir_success(mock_requests_session):
         },
     )
 
-    assert response == {"resourceType": "Bundle", "entry": [{"hello": "world"}]}
+    assert response.status_code == 200
+    assert response.json() == {"resourceType": "Bundle", "entry": [{"hello": "world"}]}
 
 
 @mock.patch("requests.Session")
@@ -225,11 +226,11 @@ def test_convert_message_to_fhir_failure(mock_requests_session):
         },
     )
 
-    assert response == {
-        "http_status_code": 400,
-        "response_content": '{ "resourceType": "Bundle", "entry": '
-        + '[{"hello": "world"}] }',
-    }
+    assert response.status_code == 400
+    assert (
+        response.text
+        == '{ "resourceType": "Bundle", "entry": ' + '[{"hello": "world"}] }'
+    )
 
 
 @mock.patch("requests.Session")
@@ -276,11 +277,11 @@ def test_log_fhir_operationoutcome(mock_log, mock_requests_session):
         },
     )
 
-    assert response == {
-        "http_status_code": 400,
-        "response_content": '{ "resourceType": "OperationOutcome", '
-        + '"diagnostics": "some-error" }',
-    }
+    assert response.status_code == 400
+    assert (
+        response.text
+        == '{ "resourceType": "OperationOutcome", ' + '"diagnostics": "some-error" }'
+    )
 
 
 @mock.patch("requests.Session")
@@ -372,7 +373,8 @@ def test_generic_error(mock_log, mock_requests_session):
         },
     )
 
-    assert response == {"http_status_code": 400, "response_content": "some-error"}
+    assert response.status_code == 400
+    assert response.text == "some-error"
 
 
 @mock.patch("requests.Session")
@@ -418,10 +420,8 @@ def test_error_with_special_chars(mock_log, mock_requests_session):
         },
     )
 
-    assert response == {
-        "http_status_code": 400,
-        "response_content": "some-error with \" special ' characters \n",
-    }
+    assert response.status_code == 400
+    assert response.text == "some-error with \" special ' characters \n"
 
 
 def test_get_filetype_mappings_valid_files():

--- a/src/lib/phdi-building-blocks/tests/test_fhir.py
+++ b/src/lib/phdi-building-blocks/tests/test_fhir.py
@@ -140,7 +140,6 @@ def test_upload_bundle_failure(mock_requests_session, mock_log_error):
     )
 
     assert response == mock_requests_return_value
-    print(mock_log_error.return_value)
     mock_log_error.assert_called_with(400)
     assert mock_log_error.call_count == 1
 
@@ -214,7 +213,6 @@ def test_upload_bundle_partial_failure(mock_requests_session, mock_log_error):
     )
 
     assert response == mock_requests_return_value
-    print(mock_log_error.return_value)
     mock_log_error.assert_called_with(status_code=400, batch_entry_index=1)
     assert mock_log_error.call_count == 1
 

--- a/src/lib/phdi-building-blocks/tests/test_fhir.py
+++ b/src/lib/phdi-building-blocks/tests/test_fhir.py
@@ -19,8 +19,9 @@ from phdi_building_blocks.fhir import (
 )
 
 
+@mock.patch("phdi_building_blocks.fhir.log_fhir_server_error")
 @mock.patch("requests.Session")
-def test_upload_bundle_to_fhir_server(mock_requests_session):
+def test_upload_bundle_to_fhir_server(mock_requests_session, mock_log_error):
     mock_requests_session_instance = mock_requests_session.return_value
 
     mock_access_token_value = "some-token"
@@ -29,7 +30,23 @@ def test_upload_bundle_to_fhir_server(mock_requests_session):
     mock_cred_manager = mock.Mock()
     mock_cred_manager.get_access_token.return_value = mock_access_token
 
-    upload_bundle_to_fhir_server(
+    mock_requests_return_value = mock.Mock(
+        status_code=200,
+        json=lambda: {
+            "resourceType": "Bundle",
+            "id": "some-id",
+            "entry": [
+                {
+                    "resource": {"resourceType": "Patient", "id": "pat-id"},
+                    "request": {"method": "PUT", "url": "Patient/pat-id"},
+                    "response": {"status": "200 OK"},
+                }
+            ],
+        },
+    )
+    mock_requests_session_instance.post.return_value = mock_requests_return_value
+
+    response = upload_bundle_to_fhir_server(
         {
             "resourceType": "Bundle",
             "id": "some-id",
@@ -62,6 +79,144 @@ def test_upload_bundle_to_fhir_server(mock_requests_session):
             ],
         },
     )
+
+    assert response == mock_requests_return_value
+    mock_log_error.assert_not_called()
+
+
+@mock.patch("phdi_building_blocks.fhir.log_fhir_server_error")
+@mock.patch("requests.Session")
+def test_upload_bundle_failure(mock_requests_session, mock_log_error):
+    mock_requests_session_instance = mock_requests_session.return_value
+
+    mock_access_token_value = "some-token"
+    mock_access_token = mock.Mock()
+    mock_access_token.token = mock_access_token_value
+    mock_cred_manager = mock.Mock()
+    mock_cred_manager.get_access_token.return_value = mock_access_token
+
+    mock_requests_return_value = mock.Mock(
+        status_code=400,
+        json=lambda: {
+            "resourceType": "OperationOutcome",
+            "severity": "error",
+        },
+    )
+
+    mock_requests_session_instance.post.return_value = mock_requests_return_value
+
+    response = upload_bundle_to_fhir_server(
+        {
+            "resourceType": "Bundle",
+            "id": "some-id",
+            "entry": [
+                {
+                    "resource": {"resourceType": "Patient", "id": "pat-id"},
+                    "request": {"method": "PUT", "url": "Patient/pat-id"},
+                }
+            ],
+        },
+        mock_cred_manager,
+        "https://some-fhir-url",
+    )
+
+    mock_requests_session_instance.post.assert_called_with(
+        url="https://some-fhir-url",
+        headers={
+            "Authorization": f"Bearer {mock_access_token_value}",
+            "Accept": "application/fhir+json",
+            "Content-Type": "application/fhir+json",
+        },
+        json={
+            "resourceType": "Bundle",
+            "id": "some-id",
+            "entry": [
+                {
+                    "resource": {"resourceType": "Patient", "id": "pat-id"},
+                    "request": {"method": "PUT", "url": "Patient/pat-id"},
+                }
+            ],
+        },
+    )
+
+    assert response == mock_requests_return_value
+    print(mock_log_error.return_value)
+    mock_log_error.assert_called_with(400)
+    assert mock_log_error.call_count == 1
+
+
+@mock.patch("phdi_building_blocks.fhir.log_fhir_server_error")
+@mock.patch("requests.Session")
+def test_upload_bundle_partial_failure(mock_requests_session, mock_log_error):
+    mock_requests_session_instance = mock_requests_session.return_value
+
+    mock_access_token_value = "some-token"
+    mock_access_token = mock.Mock()
+    mock_access_token.token = mock_access_token_value
+    mock_cred_manager = mock.Mock()
+    mock_cred_manager.get_access_token.return_value = mock_access_token
+
+    mock_requests_return_value = mock.Mock(
+        status_code=200,
+        json=lambda: {
+            "resourceType": "Bundle",
+            "entry": [
+                {
+                    "resource": {"resourceType": "Patient"},
+                    "response": {"status": "200 OK"},
+                },
+                {
+                    "resource": {"resourceType": "Organization"},
+                    "response": {"status": "400 Bad Request"},
+                },
+                {
+                    "resource": {"resourceType": "Vaccination"},
+                    "response": {"status": "200 OK"},
+                },
+            ],
+        },
+    )
+
+    mock_requests_session_instance.post.return_value = mock_requests_return_value
+
+    response = upload_bundle_to_fhir_server(
+        {
+            "resourceType": "Bundle",
+            "id": "some-id",
+            "entry": [
+                {
+                    "resource": {"resourceType": "Patient", "id": "pat-id"},
+                    "request": {"method": "PUT", "url": "Patient/pat-id"},
+                }
+            ],
+        },
+        mock_cred_manager,
+        "https://some-fhir-url",
+    )
+
+    mock_requests_session_instance.post.assert_called_with(
+        url="https://some-fhir-url",
+        headers={
+            "Authorization": f"Bearer {mock_access_token_value}",
+            "Accept": "application/fhir+json",
+            "Content-Type": "application/fhir+json",
+        },
+        json={
+            "resourceType": "Bundle",
+            "id": "some-id",
+            "entry": [
+                {
+                    "resource": {"resourceType": "Patient", "id": "pat-id"},
+                    "request": {"method": "PUT", "url": "Patient/pat-id"},
+                }
+            ],
+        },
+    )
+
+    assert response == mock_requests_return_value
+    print(mock_log_error.return_value)
+    mock_log_error.assert_called_with(status_code=400, batch_entry_index=1)
+    assert mock_log_error.call_count == 1
 
 
 @mock.patch.object(DefaultAzureCredential, "get_token")
@@ -386,6 +541,32 @@ def test_log_fhir_server_error(patched_logger):
 
     for status_code, error_message in error_status_codes.items():
         log_fhir_server_error(status_code)
+        patched_logger.error.assert_called_with(error_message)
+
+
+@mock.patch("phdi_building_blocks.fhir.logging")
+def test_log_fhir_server_error_batch(patched_logger):
+
+    log_fhir_server_error(200)
+    assert ~patched_logger.error.called
+
+    error_status_codes = {
+        401: "FHIR SERVER ERROR in entry number 0 of batch - "
+        + "Status Code 401: Failed to authenticate.",
+        403: "FHIR SERVER ERROR in entry number 1 of batch - "
+        + "Status Code 403: User does not have permission to make that request.",
+        404: "FHIR SERVER ERROR in entry number 2 of batch - "
+        + "Status Code 404: Server or requested data not found.",
+        410: "FHIR SERVER ERROR in entry number 3 of batch - "
+        + "Status Code 410: Server has deleted this cached data.",
+        499: "FHIR SERVER ERROR in entry number 4 of batch - Status code 499",
+        599: "FHIR SERVER ERROR in entry number 5 of batch - Status code 599",
+    }
+
+    for batch_index, (status_code, error_message) in enumerate(
+        error_status_codes.items()
+    ):
+        log_fhir_server_error(status_code=status_code, batch_entry_index=batch_index)
         patched_logger.error.assert_called_with(error_message)
 
 

--- a/src/lib/phdi-building-blocks/tests/test_fhir.py
+++ b/src/lib/phdi-building-blocks/tests/test_fhir.py
@@ -549,16 +549,18 @@ def test_log_fhir_server_error_batch(patched_logger):
     assert ~patched_logger.error.called
 
     error_status_codes = {
-        401: "FHIR SERVER ERROR in entry number 0 of batch - "
+        401: "FHIR SERVER ERROR in zero-based message index 0 of FHIR batch - "
         + "Status Code 401: Failed to authenticate.",
-        403: "FHIR SERVER ERROR in entry number 1 of batch - "
+        403: "FHIR SERVER ERROR in zero-based message index 1 of FHIR batch - "
         + "Status Code 403: User does not have permission to make that request.",
-        404: "FHIR SERVER ERROR in entry number 2 of batch - "
+        404: "FHIR SERVER ERROR in zero-based message index 2 of FHIR batch - "
         + "Status Code 404: Server or requested data not found.",
-        410: "FHIR SERVER ERROR in entry number 3 of batch - "
+        410: "FHIR SERVER ERROR in zero-based message index 3 of FHIR batch - "
         + "Status Code 410: Server has deleted this cached data.",
-        499: "FHIR SERVER ERROR in entry number 4 of batch - Status code 499",
-        599: "FHIR SERVER ERROR in entry number 5 of batch - Status code 599",
+        499: "FHIR SERVER ERROR in zero-based message index 4 of FHIR batch - "
+        + "Status code 499",
+        599: "FHIR SERVER ERROR in zero-based message index 5 of FHIR batch - "
+        + "Status code 599",
     }
 
     for batch_index, (status_code, error_message) in enumerate(


### PR DESCRIPTION
# Description
When uploading content to the FHIR server during resource ingestion, batches of resources are posted to the FHIR server.  Two error scenarios are:
* The whole batch transaction fails, and the FHIR server returns an HTTP error code.
* The top level batch transaction succeeds, but individual entries within the batch fail.

Previously, the system would report an entry in the error log to indicate when a whole batch failed.  Individual entry failures were ignored.  The error message did not contain information about the content of the failure.

Now, both top level, and individual entry failures are recorded in the error log in the core phdi_building_blocks library code.  

In addition, the IntakePipeline azure function uploads request and response (or individual failed entry in the case of individual entry failure) to blob storage.  This is done so users can review content and error information to help with troubleshooting.

As part of these changes, both the upload and convert functions were updated to return the `requests.Response` object returned by the FHIR server.  This was done for the Upload function to provide the caller adequate information for logging and other handling.  This was done for the Convert function for consistency reasons.

