### PR TITLE
Remove AD data from terraform storage module

### DIFF
--- a/operations/app/terraform/modules/storage/acl.tf
+++ b/operations/app/terraform/modules/storage/acl.tf
@@ -2,8 +2,6 @@ resource "azurerm_storage_data_lake_gen2_filesystem" "pdi_data" {
   for_each           = toset(local.data_containers)
   name               = each.value
   storage_account_id = azurerm_storage_account.pdi_data.id
-  owner              = data.azuread_group.owners.id
-  group              = data.azuread_group.owners.id
   properties         = {}
 
   dynamic "ace" {
@@ -26,8 +24,6 @@ resource "azurerm_storage_data_lake_gen2_path" "pdi_data_bronze" {
   filesystem_name    = azurerm_storage_data_lake_gen2_filesystem.pdi_data["bronze"].name
   storage_account_id = azurerm_storage_account.pdi_data.id
   resource           = "directory"
-  owner              = data.azuread_group.owners.id
-  group              = data.azuread_group.owners.id
   path               = "${each.value.bronze_root_dir}${each.value.bronze_sub_dir}"
 
   lifecycle {
@@ -40,8 +36,6 @@ resource "azurerm_storage_data_lake_gen2_path" "pdi_data_silver" {
   filesystem_name    = azurerm_storage_data_lake_gen2_filesystem.pdi_data["silver"].name
   storage_account_id = azurerm_storage_account.pdi_data.id
   resource           = "directory"
-  owner              = data.azuread_group.owners.id
-  group              = data.azuread_group.owners.id
   path               = "${each.value.silver_root_dir}${each.value.silver_sub_dir}"
 
   lifecycle {
@@ -54,8 +48,6 @@ resource "azurerm_storage_data_lake_gen2_path" "pdi_data_gold" {
   filesystem_name    = azurerm_storage_data_lake_gen2_filesystem.pdi_data["gold"].name
   storage_account_id = azurerm_storage_account.pdi_data.id
   resource           = "directory"
-  owner              = data.azuread_group.owners.id
-  group              = data.azuread_group.owners.id
   path               = "${each.value.gold_root_dir}${each.value.gold_sub_dir}"
 
   lifecycle {

--- a/operations/app/terraform/modules/storage/data.tf
+++ b/operations/app/terraform/modules/storage/data.tf
@@ -1,11 +1,3 @@
-data "azuread_group" "owners" {
-  display_name = var.data_access_group
-}
-
-data "azuread_service_principal" "pitest" {
-  display_name = var.data_access_sp
-}
-
 # storage account data containers and permissions
 # see docs/security/data-access.md for additional notes
 locals {

--- a/operations/app/terraform/modules/storage/~inputs.tf
+++ b/operations/app/terraform/modules/storage/~inputs.tf
@@ -57,16 +57,6 @@ variable "resource_group_id" {
   description = "Resource Group resource id"
 }
 
-variable "data_access_group" {
-  type        = string
-  description = "AD group to grant data access"
-}
-
-variable "data_access_sp" {
-  type        = string
-  description = "Service principal to grant data access"
-}
-
 variable "adf_uuid" {
   type        = string
   description = "Azure Data Factory resource uuid"

--- a/operations/app/terraform/vars/dev/main.tf
+++ b/operations/app/terraform/vars/dev/main.tf
@@ -71,8 +71,6 @@ module "storage" {
   app_subnet_ids              = module.network.app_subnet_ids
   databricks_subnet_ids       = module.network.databricks_subnet_ids
   resource_group_id           = module.resource_group.cdc_managed_resource_group_id
-  data_access_group           = var.data_access_group
-  data_access_sp              = var.data_access_sp
   adf_uuid                    = module.data_factory.adf_uuid
   python_function_app_uuid    = module.function_app.python_function_app_uuid
 }

--- a/operations/app/terraform/vars/dev/variables.tf
+++ b/operations/app/terraform/vars/dev/variables.tf
@@ -122,13 +122,3 @@ variable "terraform_caller_ip_address" {
   type    = list(string)
   default = ["162.224.209.174/32", "73.173.186.141/32", "24.163.118.70/32", "108.48.23.191/32", "173.49.171.3/32", "198.255.246.159/32", "50.237.28.214/32"]
 }
-
-variable "data_access_group" {
-  type    = string
-  default = "CT-PRIMEIngestion-AZ-Owners"
-}
-
-variable "data_access_sp" {
-  type    = string
-  default = "pitest-service-principal"
-}

--- a/operations/app/terraform/vars/test/main.tf
+++ b/operations/app/terraform/vars/test/main.tf
@@ -71,8 +71,6 @@ module "storage" {
   app_subnet_ids              = module.network.app_subnet_ids
   databricks_subnet_ids       = module.network.databricks_subnet_ids
   resource_group_id           = module.resource_group.cdc_managed_resource_group_id
-  data_access_group           = var.data_access_group
-  data_access_sp              = var.data_access_sp
   adf_uuid                    = module.data_factory.adf_uuid
   python_function_app_uuid    = module.function_app.python_function_app_uuid
 }

--- a/operations/app/terraform/vars/test/variables.tf
+++ b/operations/app/terraform/vars/test/variables.tf
@@ -122,13 +122,3 @@ variable "terraform_caller_ip_address" {
   type    = list(string)
   default = ["162.224.209.174/32", "73.173.186.141/32", "24.163.118.70/32", "108.48.23.191/32", "173.49.171.3/32", "198.255.246.159/32", "50.237.28.214/32"]
 }
-
-variable "data_access_group" {
-  type    = string
-  default = "CT-PRIMEIngestion-AZ-Owners"
-}
-
-variable "data_access_sp" {
-  type    = string
-  default = "pitest-service-principal"
-}


### PR DESCRIPTION
This PR removes some data items from our terraform `storage` module, which attempt to read the `CT-PRIMEIngestion-AZ-Contributors` group from Active Directory in Azure, so that it can get the groups ID and set it as the owner of our `pi_datasa` storage accounts. From what I can tell, this is not really necessary, as our `SU` Azure users already have the necessary permissions to be able to interact with all storage accounts in our resource groups, regardless of owners. The reason for removing this is because CDC won't give a service principal permissions to read from Active Directory, so including this will prevent us from properly implementing CD.